### PR TITLE
Fix CKAN domain, broken README clone URL, and expired-cert TLS failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Este MCP unifica **3 fuentes gubernamentales** en un solo servidor:
 
 | Fuente | Datos | Cobertura |
 |--------|-------|-----------|
-| **Datos Abiertos** (CKAN) | 1,581 datasets de 98+ instituciones | datosabiertos.presidencia.gob.ec |
+| **Datos Abiertos** (CKAN) | 1,581 datasets de 98+ instituciones | www.datosabiertos.gob.ec |
 | **Trámites** (Gob.ec) | Procedimientos gubernamentales, requisitos, costos | gob.ec/api/v1 |
 | **Categorías temáticas** | 18 categorías: Salud, Educación, Economía, etc. | Portal de datos abiertos |
 
@@ -176,8 +176,8 @@ Agrega a `~/.codeium/windsurf/mcp_config.json`:
 ### Con Docker (recomendado)
 
 ```bash
-git clone https://github.com/ecuador-mcp/ecuador-mcp.git
-cd ecuador-mcp
+git clone https://github.com/DweskZ/EcuDataMCP.git
+cd EcuDataMCP
 
 # Iniciar con configuración por defecto (puerto 8000)
 docker compose up -d
@@ -194,8 +194,8 @@ docker compose down
 Requiere Python 3.11+ y [uv](https://docs.astral.sh/uv/).
 
 ```bash
-git clone https://github.com/ecuador-mcp/ecuador-mcp.git
-cd ecuador-mcp
+git clone https://github.com/DweskZ/EcuDataMCP.git
+cd EcuDataMCP
 
 # Instalar dependencias
 uv sync
@@ -303,7 +303,7 @@ Cliente MCP (Claude, ChatGPT, Cursor, etc.)
 ├──────────────────────────────┤
 │  tools/                      │
 │   ├── search_datasets        │
-│   ├── get_dataset_info       │  → helpers/ckan_client.py → CKAN API (datosabiertos.presidencia.gob.ec)
+│   ├── get_dataset_info       │  → helpers/ckan_client.py → CKAN API (www.datosabiertos.gob.ec)
 │   ├── list_dataset_resources │
 │   ├── get_resource_info      │
 │   ├── preview_resource_data  │  → helpers/csv_reader.py  → Descarga directa CSV

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Este MCP unifica **3 fuentes gubernamentales** en un solo servidor:
 
 ## Conecta tu chatbot al servidor MCP
 
+### Opción rápida: pídeselo a tu IA
+
+Si usas un asistente con acceso a la terminal (Claude Code, Cursor, Windsurf, etc.), puedes pegarle este prompt y dejar que él mismo clone el repo, instale las dependencias y edite la configuración de tu cliente MCP:
+
+```
+Clona https://github.com/DweskZ/EcuDataMCP, instala sus dependencias con uv sync,
+y regístralo como servidor MCP en mi cliente (Claude Desktop / Claude Code / Cursor)
+usando modo stdio con `uv run --directory <ruta-del-clon> python -c "from main import mcp; mcp.run()"`.
+Verifica que el servidor responda antes de darlo por terminado.
+```
+
+Revisa siempre lo que tu asistente cambie (archivos de configuración, comandos ejecutados) antes de confirmar.
+
+### Manual
+
 ### Claude Desktop
 
 Agrega lo siguiente a tu archivo de configuración de Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` en macOS, `%APPDATA%\Claude\claude_desktop_config.json` en Windows):

--- a/helpers/ckan_client.py
+++ b/helpers/ckan_client.py
@@ -5,6 +5,7 @@ import httpx
 
 from helpers import env_config
 from helpers.logging import MAIN_LOGGER_NAME
+from helpers.tls import is_cert_verification_error
 from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
@@ -23,7 +24,24 @@ async def _fetch_json(
     assert session is not None
     try:
         logger.debug("CKAN GET %s params=%s", url, params)
-        resp = await session.get(url, params=params, timeout=_TIMEOUT)
+        try:
+            resp = await session.get(url, params=params, timeout=_TIMEOUT)
+        except httpx.ConnectError as exc:
+            if not is_cert_verification_error(exc):
+                raise
+            # www.datosabiertos.gob.ec's TLS certificate expired 2026-07-28 and
+            # has not been renewed (verified against multiple networks); retry
+            # once without verification rather than failing every CKAN-backed
+            # tool until the government renews it. Revisit once they do.
+            logger.warning(
+                "CKAN TLS verification failed for %s (portal cert expired); "
+                "retrying without verification",
+                url,
+            )
+            async with httpx.AsyncClient(
+                headers={"User-Agent": USER_AGENT}, verify=False
+            ) as insecure_session:
+                resp = await insecure_session.get(url, params=params, timeout=_TIMEOUT)
         resp.raise_for_status()
         data = resp.json()
         if not data.get("success"):

--- a/helpers/csv_reader.py
+++ b/helpers/csv_reader.py
@@ -6,12 +6,34 @@ from typing import Any
 import httpx
 
 from helpers.logging import MAIN_LOGGER_NAME
+from helpers.tls import is_cert_verification_error
 from helpers.user_agent import USER_AGENT
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 MAX_DOWNLOAD_BYTES = 5 * 1024 * 1024  # 5 MB
 _TIMEOUT = 30.0
+
+
+async def _download(session: httpx.AsyncClient, url: str) -> tuple[bytes, bool]:
+    truncated = False
+    async with session.stream("GET", url, timeout=_TIMEOUT) as resp:
+        resp.raise_for_status()
+
+        content_length = resp.headers.get("content-length")
+        if content_length and int(content_length) > MAX_DOWNLOAD_BYTES:
+            truncated = True
+
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes(chunk_size=64 * 1024):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total >= MAX_DOWNLOAD_BYTES:
+                truncated = True
+                break
+
+    return b"".join(chunks), truncated
 
 
 async def preview_csv(
@@ -31,25 +53,24 @@ async def preview_csv(
     assert session is not None
     try:
         logger.debug("Downloading CSV from %s (max %d bytes)", url, MAX_DOWNLOAD_BYTES)
-        async with session.stream("GET", url, timeout=_TIMEOUT) as resp:
-            resp.raise_for_status()
-
-            content_length = resp.headers.get("content-length")
-            if content_length and int(content_length) > MAX_DOWNLOAD_BYTES:
-                truncated = True
-            else:
-                truncated = False
-
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in resp.aiter_bytes(chunk_size=64 * 1024):
-                chunks.append(chunk)
-                total += len(chunk)
-                if total >= MAX_DOWNLOAD_BYTES:
-                    truncated = True
-                    break
-
-        raw = b"".join(chunks)
+        try:
+            raw, truncated = await _download(session, url)
+        except httpx.ConnectError as exc:
+            if not is_cert_verification_error(exc):
+                raise
+            # Same expired-certificate issue as helpers/ckan_client.py — some
+            # resource files are hosted directly on the portal domain.
+            logger.warning(
+                "TLS verification failed for %s (portal cert expired); "
+                "retrying without verification",
+                url,
+            )
+            async with httpx.AsyncClient(
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+                verify=False,
+            ) as insecure_session:
+                raw, truncated = await _download(insecure_session, url)
 
         # Strip UTF-8 BOM if present
         if raw.startswith(b"\xef\xbb\xbf"):

--- a/helpers/env_config.py
+++ b/helpers/env_config.py
@@ -1,8 +1,8 @@
 import os
 
 _API_URLS = {
-    "ckan": "https://datosabiertos.presidencia.gob.ec/api/3/action/",
-    "ckan_site": "https://datosabiertos.presidencia.gob.ec/",
+    "ckan": "https://www.datosabiertos.gob.ec/api/3/action/",
+    "ckan_site": "https://www.datosabiertos.gob.ec/",
     "gobec": "https://www.gob.ec/api/v1/",
     "gobec_site": "https://www.gob.ec/",
 }

--- a/helpers/tls.py
+++ b/helpers/tls.py
@@ -1,0 +1,24 @@
+import ssl
+
+
+def is_cert_verification_error(exc: BaseException) -> bool:
+    """Walk an exception's cause/context chain for ssl.SSLCertVerificationError.
+
+    httpx/httpcore re-wrap the raw ssl error as they propagate it, and only
+    preserve it via __context__ (implicit chaining), not __cause__ — so both
+    have to be checked to tell a real cert failure apart from other connect
+    errors (DNS, refused connection, etc.) that must not be silently retried
+    without verification.
+    """
+    seen: set[int] = set()
+    stack = [exc]
+    while stack:
+        e = stack.pop()
+        if e is None or id(e) in seen:
+            continue
+        seen.add(id(e))
+        if isinstance(e, ssl.SSLCertVerificationError):
+            return True
+        stack.append(e.__cause__)
+        stack.append(e.__context__)
+    return False

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         "Starting Ecuador MCP server v%s on %s:%d",
         VERSION, host, port,
     )
-    logger.info("CKAN API: datosabiertos.presidencia.gob.ec")
+    logger.info("CKAN API: www.datosabiertos.gob.ec")
     logger.info("GobEC API: gob.ec/api/v1")
     logger.info("MCP endpoint: http://%s:%d/mcp", host, port)
     logger.info("Health check: http://%s:%d/health", host, port)

--- a/tools/search_datasets.py
+++ b/tools/search_datasets.py
@@ -11,7 +11,7 @@ def register_search_datasets_tool(mcp: FastMCP) -> None:
         query: str, page: int = 1, page_size: int = 20, category: str = ""
     ) -> str:
         """
-        Search for datasets on Ecuador's open data portal (datosabiertos.presidencia.gob.ec).
+        Search for datasets on Ecuador's open data portal (www.datosabiertos.gob.ec).
 
         This is the starting point for exploring government data from 98+ public institutions.
         Use short, specific queries in Spanish for best results.


### PR DESCRIPTION
## Summary

- **CKAN domain fix**: the portal moved from `datosabiertos.presidencia.gob.ec` (returns 403 Forbidden, verified from multiple networks) to `www.datosabiertos.gob.ec`. Updates `helpers/env_config.py` and the references in `main.py`, `tools/search_datasets.py`, and the README.
- **README fixes**: the `git clone` commands (Docker and manual install sections) pointed to a placeholder `https://github.com/ecuador-mcp/ecuador-mcp.git` that doesn't exist — corrected to this repo. Also added a short "ask your AI to install it" section as a quick-start alternative to the manual per-client steps.
- **TLS fallback for the expired portal cert**: `www.datosabiertos.gob.ec`'s certificate expired 2026-07-28 and has not been renewed, so even with the domain fix every CKAN-backed tool (`search_datasets`, `get_dataset_info`, `preview_resource_data`, etc.) was still failing outright with `CERTIFICATE_VERIFY_FAILED`. Added `helpers/tls.py` to detect a genuine cert-verification failure (walking both `__cause__` and `__context__`, since httpx/httpcore only preserve the underlying `ssl.SSLCertVerificationError` via `__context__`) and only then retry once with verification disabled in `ckan_client.py` and `csv_reader.py`. Any other connection error still raises normally, so hosts with valid certificates are never silently downgraded. This should be reverted once the government renews the certificate.

## Test plan

- [x] Verified the new domain resolves and serves the CKAN API directly (bypassing the MCP layer)
- [x] Confirmed the previous domain (`datosabiertos.presidencia.gob.ec`) returns 403 from multiple networks
- [x] Confirmed the current cert on `www.datosabiertos.gob.ec` is expired (`openssl s_client`, `notAfter=Jul 28 23:59:59 2026 GMT`)
- [x] Ran the MCP server via stdio locally and called `search_datasets` end-to-end — it now returns real results instead of failing
- [x] Ran `search_tramites` to confirm the unrelated gob.ec-backed tools still work unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)