### PR TITLE
Explicar los 403 del portal de Datos Abiertos y sugerir una pista sobre Latinoamérica

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,21 @@ Plantillas listas para el cliente (Claude/Cursor): `explorar_datos`, `consultar_
 
 ---
 
+## Problema conocido: el portal de Datos Abiertos a veces bloquea conexiones
+
+El portal `www.datosabiertos.gob.ec` a veces rechaza las conexiones que vienen de fuera de Latinoamérica (error 403). Esto afecta a las herramientas que dependen de ese portal: `search_datasets`, `search_organizations`, `get_organization_info`, `get_dataset_info`, `list_dataset_resources`, `get_resource_info`, `preview_resource_data`, `query_resource_data`, `list_recent_datasets`, `list_categories` y `get_category_info`.
+
+En nuestras pruebas:
+- Conectando desde Canadá: bloqueado.
+- Conectando desde Estados Unidos: bloqueado.
+- Conectando desde Colombia: funcionó sin problemas.
+
+Las herramientas de trámites e instituciones (`search_tramites`, `list_instituciones`, `get_institucion_info`, etc.) usan otro portal (`gob.ec`) y no tienen este problema.
+
+**Si ves errores 403 en las herramientas de Datos Abiertos:** intenta correr el servidor desde una conexión (por ejemplo, una VPN) con salida en algún país de Latinoamérica.
+
+---
+
 ## Ejemplos de uso
 
 ### Buscar datos del SRI

--- a/helpers/ckan_client.py
+++ b/helpers/ckan_client.py
@@ -43,6 +43,18 @@ async def _fetch_json(
                 headers={"User-Agent": USER_AGENT}, verify=False
             ) as insecure_session:
                 resp = await insecure_session.get(url, params=params, timeout=_TIMEOUT)
+        if resp.status_code == 403:
+            # The portal has been observed rejecting connections from outside
+            # Latin America (403) while accepting them from the region. Give
+            # callers a message that points at the likely cause instead of a
+            # bare "403 Forbidden".
+            logger.warning("CKAN request to %s got 403 Forbidden", url)
+            raise RuntimeError(
+                "El portal de Datos Abiertos (datosabiertos.gob.ec) rechazó la "
+                "conexión (403). Esto suele pasar cuando el servidor se conecta "
+                "desde fuera de Latinoamérica. Si el problema persiste, prueba "
+                "conectando desde una VPN con salida en algún país de la región."
+            )
         resp.raise_for_status()
         data = resp.json()
         if not data.get("success"):

--- a/test_server.py
+++ b/test_server.py
@@ -6,6 +6,7 @@ Make sure the server is running on http://localhost:8000 first.
 
 import asyncio
 import json
+
 import httpx
 
 MCP_URL = "http://localhost:8000/mcp"


### PR DESCRIPTION
## Resumen
- El portal de Datos Abiertos (`www.datosabiertos.gob.ec`) a veces rechaza las conexiones con un `403 Forbidden` sin más explicación. Lo reproduje conectándome desde Canadá y desde Estados Unidos (vía VPN); una conexión desde Colombia funcionó sin problemas con las mismas solicitudes.
- `helpers/ckan_client.py` ahora lanza un mensaje en español explicando la causa más probable (conexión desde fuera de Latinoamérica) en lugar de mostrar el 403 sin contexto, para todas las herramientas que dependen de CKAN.
- El README documenta el patrón observado y sugiere una solución (conectar el servidor desde una VPN con salida en Latinoamérica) para quien se tope con este problema.

Esto se basa en pruebas reproducibles, no en una explicación oficial del portal — con gusto ajusto el texto si tienes más visibilidad sobre la causa real.

## Plan de pruebas
- [x] `python -m pytest tests/` — 27 pruebas pasaron
- [x] Corrí el smoke suite local (`scripts/smoke_e2e.py`) contra un servidor corriendo — las herramientas de CKAN pasan desde una conexión en Latinoamérica
- [x] Confirmé manualmente que el nuevo mensaje de 403 aparece al llamar `search_datasets` estando conectado por VPN desde Estados Unidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)