### PR TITLE
Agregar search_anda: catálogo de encuestas y censos del INEC (ANDA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (25 tools)
+## Herramientas disponibles (26 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -282,6 +282,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | Tool | Descripción |
 |------|-------------|
 | `search_anda` | Buscar encuestas y censos en el catálogo ANDA del INEC (NADA/IHSN). Indica si cada encuesta tiene microdatos descargables. |
+| `get_anda_survey_info` | Metadata completa de una encuesta ANDA: resumen, variables, confidencialidad y contacto. |
 
 ### Regulaciones y contratos
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (26 tools)
+## Herramientas disponibles (27 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -283,6 +283,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 |------|-------------|
 | `search_anda` | Buscar encuestas y censos en el catálogo ANDA del INEC (NADA/IHSN). Indica si cada encuesta tiene microdatos descargables. |
 | `get_anda_survey_info` | Metadata completa de una encuesta ANDA: resumen, variables, confidencialidad y contacto. |
+| `download_anda_microdata` | Links directos de descarga de los archivos de microdatos de una encuesta ANDA. |
 
 ### Regulaciones y contratos
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Este MCP unifica **fuentes gubernamentales** en un solo servidor:
 | **Contratos públicos** (SERCOP/OCDS) | Licitaciones, compradores, proveedores | datosabiertos.compraspublicas.gob.ec |
 | **Gestión de Riesgos** (SGR) | Eventos COE + estaciones SAT tsunami | sgrportal.gestionderiesgos.gob.ec |
 | **Geografía** (DPA) | 24 provincias + 224 cantones (códigos INEC) | referencia offline |
+| **ANDA** (NADA/IHSN) | Catálogo de encuestas y censos del INEC | anda.inec.gob.ec |
 
 **Sin API key. Sin restricciones de acceso. 100% datos públicos.**
 
@@ -243,7 +244,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (24 tools)
+## Herramientas disponibles (25 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -275,6 +276,12 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `get_tramite_info` | Detalle completo: requisitos, procedimiento, costo, tiempo estimado. |
 | `list_instituciones` | Listar instituciones públicas del Ecuador. |
 | `get_institucion_info` | Detalle de una institución (sector, web, descripción). |
+
+### ANDA (INEC)
+
+| Tool | Descripción |
+|------|-------------|
+| `search_anda` | Buscar encuestas y censos en el catálogo ANDA del INEC (NADA/IHSN). Indica si cada encuesta tiene microdatos descargables. |
 
 ### Regulaciones y contratos
 

--- a/helpers/anda_client.py
+++ b/helpers/anda_client.py
@@ -12,9 +12,12 @@ logger = logging.getLogger(MAIN_LOGGER_NAME)
 _TIMEOUT = 20.0
 
 # NADA marks surveys with no microdata attached (aggregate-only publications,
-# e.g. price indices) as form_model "data_na". Anything else ("direct",
-# "external", etc.) means the survey has actual microdata behind it.
-NO_MICRODATA_FORM_MODEL = "data_na"
+# e.g. price indices) as "data_na" — in the catalog list endpoint that's the
+# form_model field, in the per-survey detail endpoint it's data_access_type.
+# Anything else ("direct", "external", etc.) means the survey has actual
+# microdata behind it. data_class_id looks like the obvious field to check
+# but it comes back null on every survey regardless of access — don't use it.
+NO_MICRODATA_VALUE = "data_na"
 
 
 def _anda_url(path: str) -> str:
@@ -54,6 +57,42 @@ async def search_catalog(
             await session.aclose()
 
 
+async def get_survey(
+    idno: str,
+    session: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Fetch full DDI-style metadata for one survey by its idno (not its numeric id)."""
+    own = session is None
+    if own:
+        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+    assert session is not None
+    try:
+        logger.debug("ANDA GET catalog detail idno=%s", idno)
+        resp = await session.get(
+            _anda_url(f"catalog/{idno}"), timeout=_TIMEOUT, follow_redirects=True
+        )
+        if resp.status_code == 400:
+            try:
+                message = resp.json().get("message", "")
+            except ValueError:
+                message = ""
+            if message == "IDNO-NOT-FOUND":
+                raise ValueError(f"No se encontró ninguna encuesta con idno '{idno}' en ANDA.")
+        resp.raise_for_status()
+        return resp.json().get("dataset", {})
+    except httpx.HTTPError as exc:
+        logger.error("ANDA survey detail request failed for %s: %s", idno, exc)
+        raise
+    finally:
+        if own:
+            await session.aclose()
+
+
 def has_microdata(row: dict[str, Any]) -> bool:
-    """True if a catalog entry has downloadable microdata, not just aggregates."""
-    return row.get("form_model") != NO_MICRODATA_FORM_MODEL
+    """True if a catalog entry has downloadable microdata, not just aggregates.
+
+    Catalog-list rows use `form_model`; per-survey detail records use
+    `data_access_type` instead. Check whichever is present.
+    """
+    value = row.get("form_model", row.get("data_access_type"))
+    return value != NO_MICRODATA_VALUE

--- a/helpers/anda_client.py
+++ b/helpers/anda_client.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any
+
+import httpx
+
+from helpers import env_config
+from helpers.logging import MAIN_LOGGER_NAME
+from helpers.user_agent import USER_AGENT
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+_TIMEOUT = 20.0
+
+# NADA marks surveys with no microdata attached (aggregate-only publications,
+# e.g. price indices) as form_model "data_na". Anything else ("direct",
+# "external", etc.) means the survey has actual microdata behind it.
+NO_MICRODATA_FORM_MODEL = "data_na"
+
+
+def _anda_url(path: str) -> str:
+    return f"{env_config.get_base_url('anda')}{path}"
+
+
+async def search_catalog(
+    query: str = "",
+    limit: int = 10,
+    session: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Search the ANDA (NADA) survey/census catalog.
+
+    ANDA's full-text search (`sk`) is loose — multi-word queries are matched
+    fairly broadly rather than as a strict AND, so short specific keywords
+    work better than long phrases.
+    """
+    own = session is None
+    if own:
+        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+    assert session is not None
+    try:
+        params: dict[str, Any] = {"ps": min(limit, 50)}
+        if query:
+            params["sk"] = query
+        logger.debug("ANDA GET catalog params=%s", params)
+        resp = await session.get(
+            _anda_url("catalog"), params=params, timeout=_TIMEOUT, follow_redirects=True
+        )
+        resp.raise_for_status()
+        return resp.json().get("result", {})
+    except httpx.HTTPError as exc:
+        logger.error("ANDA request failed: %s", exc)
+        raise
+    finally:
+        if own:
+            await session.aclose()
+
+
+def has_microdata(row: dict[str, Any]) -> bool:
+    """True if a catalog entry has downloadable microdata, not just aggregates."""
+    return row.get("form_model") != NO_MICRODATA_FORM_MODEL

--- a/helpers/anda_client.py
+++ b/helpers/anda_client.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 import httpx
@@ -10,6 +11,12 @@ from helpers.user_agent import USER_AGENT
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 
 _TIMEOUT = 20.0
+
+_CSRF_RE = re.compile(r'name="ncsrf"\s+value="([a-f0-9]+)"')
+_DOWNLOAD_LINK_RE = re.compile(
+    r'href="(https://anda\.inec\.gob\.ec/anda5/index\.php/catalog/\d+/download/\d+)"'
+    r'[^>]*title="([^"]+)"'
+)
 
 # NADA marks surveys with no microdata attached (aggregate-only publications,
 # e.g. price indices) as "data_na" — in the catalog list endpoint that's the
@@ -82,6 +89,55 @@ async def get_survey(
         return resp.json().get("dataset", {})
     except httpx.HTTPError as exc:
         logger.error("ANDA survey detail request failed for %s: %s", idno, exc)
+        raise
+    finally:
+        if own:
+            await session.aclose()
+
+
+async def list_microdata_files(
+    survey_id: str,
+    session: httpx.AsyncClient | None = None,
+) -> list[dict[str, str]]:
+    """Discover direct download links for a survey's microdata files.
+
+    ANDA gates the file list behind a one-click usage-terms form (research/
+    statistical use only, no re-identifying respondents, cite the source) on
+    the "get-microdata" page before showing download links. This walks that
+    flow — GET the page for its CSRF token, POST acceptance — to reveal them.
+
+    The download URLs themselves turned out to require no session or cookie
+    at all once known: a plain GET from a fresh client with no prior request
+    returns the file directly. So nothing from this session needs to carry
+    over to actually fetch a file — these links work on their own.
+
+    Takes the survey's numeric id (not its idno) since that's what the
+    get-microdata URL is keyed on; get it from get_survey()'s "id" field.
+    """
+    own = session is None
+    if own:
+        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+    assert session is not None
+    try:
+        url = f"{env_config.get_base_url('anda_site')}index.php/catalog/{survey_id}/get-microdata"
+        page = await session.get(url, timeout=_TIMEOUT, follow_redirects=True)
+        page.raise_for_status()
+        token_match = _CSRF_RE.search(page.text)
+        if not token_match:
+            return []
+        resp = await session.post(
+            url,
+            data={"ncsrf": token_match.group(1), "accept": "Aceptar"},
+            timeout=_TIMEOUT,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        files: dict[str, str] = {}
+        for link, filename in _DOWNLOAD_LINK_RE.findall(resp.text):
+            files[link] = filename
+        return [{"filename": name, "url": link} for link, name in files.items()]
+    except httpx.HTTPError as exc:
+        logger.error("ANDA microdata file listing failed for id=%s: %s", survey_id, exc)
         raise
     finally:
         if own:

--- a/helpers/env_config.py
+++ b/helpers/env_config.py
@@ -7,6 +7,8 @@ _API_URLS = {
     "gobec_site": "https://www.gob.ec/",
     "sercop": "https://datosabiertos.compraspublicas.gob.ec/PLATAFORMA/api/",
     "sercop_site": "https://datosabiertos.compraspublicas.gob.ec/PLATAFORMA/",
+    "anda": "https://anda.inec.gob.ec/anda5/index.php/api/",
+    "anda_site": "https://anda.inec.gob.ec/anda5/",
 }
 
 _ENV_OVERRIDES = {
@@ -16,6 +18,8 @@ _ENV_OVERRIDES = {
     "gobec_site": "GOBEC_SITE_URL",
     "sercop": "SERCOP_API_URL",
     "sercop_site": "SERCOP_SITE_URL",
+    "anda": "ANDA_API_URL",
+    "anda_site": "ANDA_SITE_URL",
 }
 
 

--- a/tests/test_anda_client.py
+++ b/tests/test_anda_client.py
@@ -81,3 +81,45 @@ async def test_get_survey_not_found(httpx_mock):
     )
     with pytest.raises(ValueError, match="No se encontró"):
         await anda_client.get_survey("NOPE")
+
+
+@pytest.mark.asyncio
+async def test_list_microdata_files(httpx_mock):
+    get_microdata_url = "https://anda.inec.gob.ec/anda5/index.php/catalog/1153/get-microdata"
+    httpx_mock.add_response(
+        method="GET",
+        url=get_microdata_url,
+        html='<form><input type="hidden" name="ncsrf" value="abc123def456" /></form>',
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=get_microdata_url,
+        html=(
+            '<a href="https://anda.inec.gob.ec/anda5/index.php/catalog/1153/download/1" '
+            'title="archivo_a.zip">a</a>'
+            '<a href="https://anda.inec.gob.ec/anda5/index.php/catalog/1153/download/2" '
+            'title="archivo_b.zip">b</a>'
+        ),
+    )
+    files = await anda_client.list_microdata_files("1153")
+    assert files == [
+        {
+            "filename": "archivo_a.zip",
+            "url": "https://anda.inec.gob.ec/anda5/index.php/catalog/1153/download/1",
+        },
+        {
+            "filename": "archivo_b.zip",
+            "url": "https://anda.inec.gob.ec/anda5/index.php/catalog/1153/download/2",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_microdata_files_no_csrf_token(httpx_mock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://anda.inec.gob.ec/anda5/index.php/catalog/1/get-microdata",
+        html="<p>no form here</p>",
+    )
+    files = await anda_client.list_microdata_files("1")
+    assert files == []

--- a/tests/test_anda_client.py
+++ b/tests/test_anda_client.py
@@ -1,0 +1,47 @@
+import pytest
+
+from helpers import anda_client
+
+
+@pytest.mark.asyncio
+async def test_search_catalog(httpx_mock):
+    httpx_mock.add_response(
+        url="https://anda.inec.gob.ec/anda5/index.php/api/catalog?ps=10&sk=empleo",
+        json={
+            "result": {
+                "found": "1",
+                "rows": [
+                    {
+                        "id": "1319",
+                        "idno": "ECU-INEC-EMPLEO-2025",
+                        "title": "Encuesta de Empleo 2025",
+                        "year_start": "2025",
+                        "authoring_entity": "INEC",
+                        "form_model": "direct",
+                        "url": "https://anda.inec.gob.ec/anda5/index.php/catalog/1319",
+                    }
+                ],
+            }
+        },
+    )
+    result = await anda_client.search_catalog(query="empleo", limit=10)
+    assert result["found"] == "1"
+    assert result["rows"][0]["idno"] == "ECU-INEC-EMPLEO-2025"
+
+
+@pytest.mark.asyncio
+async def test_search_catalog_no_query(httpx_mock):
+    httpx_mock.add_response(
+        url="https://anda.inec.gob.ec/anda5/index.php/api/catalog?ps=5",
+        json={"result": {"found": "437", "rows": []}},
+    )
+    result = await anda_client.search_catalog(limit=5)
+    assert result["found"] == "437"
+
+
+def test_has_microdata_direct():
+    assert anda_client.has_microdata({"form_model": "direct"}) is True
+
+
+def test_has_microdata_aggregate_only():
+    assert anda_client.has_microdata({"form_model": "data_na"}) is False

--- a/tests/test_anda_client.py
+++ b/tests/test_anda_client.py
@@ -45,3 +45,39 @@ def test_has_microdata_direct():
 
 def test_has_microdata_aggregate_only():
     assert anda_client.has_microdata({"form_model": "data_na"}) is False
+
+
+def test_has_microdata_from_detail_field():
+    assert anda_client.has_microdata({"data_access_type": "direct"}) is True
+    assert anda_client.has_microdata({"data_access_type": "data_na"}) is False
+
+
+@pytest.mark.asyncio
+async def test_get_survey(httpx_mock):
+    httpx_mock.add_response(
+        url="https://anda.inec.gob.ec/anda5/index.php/api/catalog/ECU-INEC-EMPLEO-2025",
+        json={
+            "status": "success",
+            "dataset": {
+                "id": "1319",
+                "idno": "ECU-INEC-EMPLEO-2025",
+                "title": "Encuesta de Empleo 2025",
+                "data_access_type": "direct",
+                "varcount": "150",
+            },
+        },
+    )
+    dataset = await anda_client.get_survey("ECU-INEC-EMPLEO-2025")
+    assert dataset["id"] == "1319"
+    assert dataset["varcount"] == "150"
+
+
+@pytest.mark.asyncio
+async def test_get_survey_not_found(httpx_mock):
+    httpx_mock.add_response(
+        url="https://anda.inec.gob.ec/anda5/index.php/api/catalog/NOPE",
+        status_code=400,
+        json={"status": "failed", "message": "IDNO-NOT-FOUND"},
+    )
+    with pytest.raises(ValueError, match="No se encontró"):
+        await anda_client.get_survey("NOPE")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,5 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 
+from tools.download_anda_microdata import register_download_anda_microdata_tool
 from tools.get_anda_survey_info import register_get_anda_survey_info_tool
 from tools.get_category_info import register_get_category_info_tool
 from tools.get_contrato_info import register_get_contrato_info_tool
@@ -55,6 +56,7 @@ def register_tools(mcp: FastMCP) -> None:
 
     register_search_anda_tool(mcp)
     register_get_anda_survey_info_tool(mcp)
+    register_download_anda_microdata_tool(mcp)
 
     register_search_regulaciones_tool(mcp)
     register_get_regulacion_info_tool(mcp)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,5 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 
+from tools.get_anda_survey_info import register_get_anda_survey_info_tool
 from tools.get_category_info import register_get_category_info_tool
 from tools.get_contrato_info import register_get_contrato_info_tool
 from tools.get_dataset_info import register_get_dataset_info_tool
@@ -53,6 +54,7 @@ def register_tools(mcp: FastMCP) -> None:
     register_get_institucion_info_tool(mcp)
 
     register_search_anda_tool(mcp)
+    register_get_anda_survey_info_tool(mcp)
 
     register_search_regulaciones_tool(mcp)
     register_get_regulacion_info_tool(mcp)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -17,6 +17,7 @@ from tools.list_sat_tsunami import register_list_sat_tsunami_tool
 from tools.lookup_ubicacion import register_lookup_ubicacion_tool
 from tools.preview_resource_data import register_preview_resource_data_tool
 from tools.query_resource_data import register_query_resource_data_tool
+from tools.search_anda import register_search_anda_tool
 from tools.search_contratos import register_search_contratos_tool
 from tools.search_datasets import register_search_datasets_tool
 from tools.search_ecuador import register_search_ecuador_tool
@@ -50,6 +51,8 @@ def register_tools(mcp: FastMCP) -> None:
     register_get_tramite_info_tool(mcp)
     register_list_instituciones_tool(mcp)
     register_get_institucion_info_tool(mcp)
+
+    register_search_anda_tool(mcp)
 
     register_search_regulaciones_tool(mcp)
     register_get_regulacion_info_tool(mcp)

--- a/tools/download_anda_microdata.py
+++ b/tools/download_anda_microdata.py
@@ -1,0 +1,79 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import anda_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_download_anda_microdata_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def download_anda_microdata(idno: str, format: str = "text") -> str:
+        """
+        Get direct download links for an ANDA survey's microdata files.
+
+        Automates ANDA's one-click usage-terms step (research/statistical use
+        only, no re-identifying respondents, cite the source — see
+        get_anda_survey_info for the full text) to reveal the file list. Check
+        get_anda_survey_info first: aggregate-only surveys (microdatos_disponibles
+        false) have no files here.
+
+        Returns direct URLs, not the file contents — the files are typically
+        multi-MB ZIPs (SPSS .sav inside), too large to embed in a tool result.
+        Download them with the returned URL.
+
+        Args:
+            idno: Survey identifier from search_anda (the "idno" field)
+            format: text | json
+        """
+        try:
+            dataset = await anda_client.get_survey(idno)
+            survey_id = dataset.get("id")
+            if not survey_id:
+                raise ValueError(f"No se encontró ninguna encuesta con idno '{idno}' en ANDA.")
+
+            if not anda_client.has_microdata(dataset):
+                return render_output(
+                    {"idno": idno, "titulo": dataset.get("title"), "archivos": []},
+                    format,
+                    text_builder=lambda d: (
+                        f"'{d['titulo']}' no tiene microdatos descargables, solo agregados. "
+                        "Usa get_anda_survey_info para ver el contacto y solicitar acceso."
+                    ),
+                )
+
+            files = await anda_client.list_microdata_files(survey_id)
+        except Exception as e:
+            return render_output(
+                {"error": str(e), "idno": idno},
+                format,
+                text_builder=lambda d: f"Error al obtener los archivos: {d['error']}",
+            )
+
+        payload = {
+            "idno": idno,
+            "titulo": dataset.get("title"),
+            "total_archivos": len(files),
+            "archivos": files,
+        }
+
+        def to_text(data: dict) -> str:
+            if not data["archivos"]:
+                return (
+                    f"No se encontraron archivos de microdatos para '{data['titulo']}' "
+                    "(la página de descarga no devolvió links; puede necesitar revisión manual)."
+                )
+            parts = [
+                f"Archivos de microdatos para: {data['titulo']}",
+                (
+                    "Uso sujeto a los términos de ANDA (fines estadísticos/investigación, "
+                    "no reidentificar encuestados, citar la fuente — ver get_anda_survey_info)."
+                ),
+                "",
+            ]
+            for f in data["archivos"]:
+                parts.append(f"- {f['filename']}")
+                parts.append(f"  {f['url']}")
+            return "\n".join(parts)
+
+        return render_output(payload, format, text_builder=to_text)

--- a/tools/get_anda_survey_info.py
+++ b/tools/get_anda_survey_info.py
@@ -1,0 +1,112 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import anda_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+_MAX_TEXT_CHARS = 800
+
+
+def _trim(text: str, n: int = _MAX_TEXT_CHARS) -> str | None:
+    clean = " ".join((text or "").split())
+    if not clean:
+        return None
+    return clean[:n] + "..." if len(clean) > n else clean
+
+
+def register_get_anda_survey_info_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def get_anda_survey_info(idno: str, format: str = "text") -> str:
+        """
+        Get full metadata for one ANDA (INEC) survey/census by its idno.
+
+        Get the idno from search_anda results — it's the string identifier
+        (e.g. "IDD-ECU-INEC-CGTPE-DECON-ENESEM-2023-v1.3"), not the numeric id.
+
+        Returns scope/abstract, variable count, whether microdata is actually
+        downloadable, confidentiality terms, and a contact email for requesting
+        restricted data when it isn't.
+
+        Args:
+            idno: Survey identifier from search_anda (the "idno" field)
+            format: text | json
+        """
+        try:
+            dataset = await anda_client.get_survey(idno)
+        except Exception as e:
+            return render_output(
+                {"error": str(e), "idno": idno},
+                format,
+                text_builder=lambda d: f"Error al obtener la encuesta: {d['error']}",
+            )
+
+        study_desc = dataset.get("metadata", {}).get("study_desc", {})
+        study_info = study_desc.get("study_info", {})
+        dataset_use = study_desc.get("data_access", {}).get("dataset_use", {})
+
+        conf_dec = dataset_use.get("conf_dec") or []
+        contacts = dataset_use.get("contact") or []
+
+        payload = {
+            "id": dataset.get("id"),
+            "idno": dataset.get("idno"),
+            "titulo": dataset.get("title"),
+            "anio_inicio": dataset.get("year_start"),
+            "anio_fin": dataset.get("year_end"),
+            "entidad": dataset.get("authoring_entity"),
+            "microdatos_disponibles": anda_client.has_microdata(dataset),
+            "variables": dataset.get("varcount"),
+            "vistas": dataset.get("total_views"),
+            "descargas": dataset.get("total_downloads"),
+            "resumen": _trim(study_info.get("abstract", "")),
+            "confidencialidad": _trim(conf_dec[0].get("txt", "")) if conf_dec else None,
+            "contacto_email": contacts[0].get("email") if contacts else None,
+            "url": (
+                f"https://anda.inec.gob.ec/anda5/index.php/catalog/{dataset['id']}"
+                if dataset.get("id")
+                else None
+            ),
+        }
+
+        def to_text(data: dict) -> str:
+            parts = [
+                f"Encuesta: {data.get('titulo', 'Sin título')}",
+                f"idno: {data['idno']}",
+                f"ID: {data.get('id')}",
+            ]
+            anio_inicio, anio_fin = data.get("anio_inicio"), data.get("anio_fin")
+            if anio_inicio:
+                rango = (
+                    f"{anio_inicio} - {anio_fin}"
+                    if anio_fin and anio_fin != anio_inicio
+                    else str(anio_inicio)
+                )
+                parts.append(f"Año: {rango}")
+            if data.get("entidad"):
+                parts.append(f"Entidad: {data['entidad']}")
+
+            microdatos = "sí" if data["microdatos_disponibles"] else "no (solo agregados)"
+            parts.append(f"Microdatos disponibles: {microdatos}")
+            if data.get("variables"):
+                parts.append(f"Variables documentadas: {data['variables']}")
+            if data.get("vistas") or data.get("descargas"):
+                parts.append(
+                    f"Vistas: {data.get('vistas', 0)} · Descargas: {data.get('descargas', 0)}"
+                )
+
+            if data.get("resumen"):
+                parts.append("")
+                parts.append(f"Resumen: {data['resumen']}")
+            if data.get("confidencialidad"):
+                parts.append("")
+                parts.append(f"Confidencialidad: {data['confidencialidad']}")
+            if data.get("contacto_email"):
+                parts.append("")
+                parts.append(f"Contacto para solicitar datos: {data['contacto_email']}")
+            if data.get("url"):
+                parts.append("")
+                parts.append(f"URL: {data['url']}")
+            return "\n".join(parts)
+
+        return render_output(payload, format, text_builder=to_text)

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -36,7 +36,7 @@ _CAPABILITIES = {
         "compras": ["search_contratos", "get_contrato_info"],
         "riesgos": ["search_eventos_riesgo", "list_sat_tsunami"],
         "geo": ["lookup_ubicacion"],
-        "encuestas": ["search_anda"],
+        "encuestas": ["search_anda", "get_anda_survey_info"],
     },
     "resources": [
         "ecuador://fuentes",

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -36,7 +36,7 @@ _CAPABILITIES = {
         "compras": ["search_contratos", "get_contrato_info"],
         "riesgos": ["search_eventos_riesgo", "list_sat_tsunami"],
         "geo": ["lookup_ubicacion"],
-        "encuestas": ["search_anda", "get_anda_survey_info"],
+        "encuestas": ["search_anda", "get_anda_survey_info", "download_anda_microdata"],
     },
     "resources": [
         "ecuador://fuentes",

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -12,6 +12,7 @@ _CAPABILITIES = {
         "SERCOP OCDS contratos",
         "SGR COE eventos de riesgo + SAT tsunami",
         "DPA provincias/cantones/parroquias (offline INEC)",
+        "ANDA (NADA/IHSN) catálogo de encuestas y censos del INEC",
     ],
     "entrada": [
         "list_capabilities",
@@ -35,6 +36,7 @@ _CAPABILITIES = {
         "compras": ["search_contratos", "get_contrato_info"],
         "riesgos": ["search_eventos_riesgo", "list_sat_tsunami"],
         "geo": ["lookup_ubicacion"],
+        "encuestas": ["search_anda"],
     },
     "resources": [
         "ecuador://fuentes",

--- a/tools/search_anda.py
+++ b/tools/search_anda.py
@@ -1,0 +1,73 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import anda_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_search_anda_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def search_anda(query: str = "", limit: int = 10, format: str = "text") -> str:
+        """
+        Search INEC's ANDA catalog (anda.inec.gob.ec) of surveys and censuses.
+
+        ANDA runs on NADA (World Bank/IHSN), separate from datosabiertos.gob.ec.
+        It catalogs 437+ INEC surveys/censuses with metadata (title, year,
+        authoring entity). Not every entry has downloadable microdata — many are
+        aggregate-only publications (e.g. price indices); each result says so.
+
+        Use short, specific keywords in Spanish — multi-word queries are matched
+        loosely, not as a strict AND.
+
+        Args:
+            query: Search keywords (e.g. "empleo", "REEM", "censo agropecuario")
+            limit: Max results (default: 10, max: 50)
+            format: text | json
+        """
+        try:
+            result = await anda_client.search_catalog(query=query, limit=limit)
+        except Exception as e:
+            return render_output(
+                {"error": str(e)},
+                format,
+                text_builder=lambda d: f"Error al buscar en ANDA: {d['error']}",
+            )
+
+        rows = result.get("rows", [])
+        payload = {
+            "query": query,
+            "total": result.get("found", 0),
+            "results": [
+                {
+                    "id": r.get("id"),
+                    "idno": r.get("idno"),
+                    "titulo": r.get("title"),
+                    "anio": r.get("year_start"),
+                    "entidad": r.get("authoring_entity"),
+                    "microdatos_disponibles": anda_client.has_microdata(r),
+                    "url": r.get("url"),
+                }
+                for r in rows
+            ],
+        }
+
+        def to_text(data: dict) -> str:
+            rows = data.get("results") or []
+            if not rows:
+                return f"No se encontraron encuestas en ANDA para: '{data['query']}'"
+            parts = [
+                f"Se encontraron {data['total']} encuesta(s) en ANDA para: '{data['query']}'",
+                f"Mostrando {len(rows)} resultados:\n",
+            ]
+            for i, r in enumerate(rows, 1):
+                parts.append(f"{i}. {r.get('titulo', 'Sin título')} ({r.get('anio', '?')})")
+                parts.append(f"   ID: {r.get('id')} · idno: {r.get('idno')}")
+                parts.append(f"   Entidad: {r.get('entidad')}")
+                microdatos = "sí" if r.get("microdatos_disponibles") else "no (solo agregados)"
+                parts.append(f"   Microdatos disponibles: {microdatos}")
+                parts.append(f"   URL: {r.get('url')}")
+                parts.append("")
+            return "\n".join(parts)
+
+        return render_output(payload, format, text_builder=to_text)

--- a/tools/search_anda.py
+++ b/tools/search_anda.py
@@ -1,8 +1,29 @@
+from unicodedata import category, normalize
+
 from mcp.server.fastmcp import FastMCP
 
 from helpers import anda_client
 from helpers.format_out import render_output
 from helpers.logging import log_tool
+
+# ANDA's own full-text search (`sk`) is loose — it ranks by relevance across
+# a broad blob of fields rather than requiring every query word to match, so
+# a search for "ENESEM" also surfaces REEM, price indices, etc. Fetch a wider
+# candidate batch and filter locally so results actually contain the query.
+_FETCH_SIZE = 100
+
+
+def _strip_accents(text: str) -> str:
+    nfkd = normalize("NFKD", text or "")
+    return "".join(c for c in nfkd if category(c) != "Mn")
+
+
+def _matches_query(row: dict, words: list[str]) -> bool:
+    blob = _strip_accents(
+        f"{row.get('title', '')} {row.get('subtitle', '')} "
+        f"{row.get('idno', '')} {row.get('authoring_entity', '')}"
+    ).lower()
+    return all(w in blob for w in words)
 
 
 def register_search_anda_tool(mcp: FastMCP) -> None:
@@ -17,16 +38,24 @@ def register_search_anda_tool(mcp: FastMCP) -> None:
         authoring entity). Not every entry has downloadable microdata — many are
         aggregate-only publications (e.g. price indices); each result says so.
 
-        Use short, specific keywords in Spanish — multi-word queries are matched
-        loosely, not as a strict AND.
+        Follow up with get_anda_survey_info(idno) for full metadata on one survey.
 
         Args:
             query: Search keywords (e.g. "empleo", "REEM", "censo agropecuario")
             limit: Max results (default: 10, max: 50)
             format: text | json
         """
+        words = [_strip_accents(w.lower()) for w in query.split() if len(w) >= 2]
         try:
-            result = await anda_client.search_catalog(query=query, limit=limit)
+            if words:
+                result = await anda_client.search_catalog(query=query, limit=_FETCH_SIZE)
+                candidates = result.get("rows", [])
+                matched = [r for r in candidates if _matches_query(r, words)]
+                total_scanned = len(candidates)
+            else:
+                result = await anda_client.search_catalog(limit=limit)
+                matched = result.get("rows", [])
+                total_scanned = len(matched)
         except Exception as e:
             return render_output(
                 {"error": str(e)},
@@ -34,10 +63,11 @@ def register_search_anda_tool(mcp: FastMCP) -> None:
                 text_builder=lambda d: f"Error al buscar en ANDA: {d['error']}",
             )
 
-        rows = result.get("rows", [])
+        total = len(matched)
         payload = {
             "query": query,
-            "total": result.get("found", 0),
+            "total": total,
+            "total_scanned": total_scanned,
             "results": [
                 {
                     "id": r.get("id"),
@@ -48,7 +78,7 @@ def register_search_anda_tool(mcp: FastMCP) -> None:
                     "microdatos_disponibles": anda_client.has_microdata(r),
                     "url": r.get("url"),
                 }
-                for r in rows
+                for r in matched[:limit]
             ],
         }
 


### PR DESCRIPTION
## Resumen
- Nueva herramienta `search_anda` que busca en el catálogo ANDA del INEC (`anda.inec.gob.ec`), separado de `datosabiertos.gob.ec`. Corre sobre NADA, el catálogo estándar del Banco Mundial/IHSN, con 437+ encuestas y censos.
- Cada resultado indica si la encuesta tiene **microdatos descargables** o es solo un agregado publicado (ej. índices de precios). Esto se calcula con el campo `form_model`/`data_access_type` de la API — `data_class_id` siempre viene `null`, así que no sirve como indicador aunque parezca el candidato obvio.
- Nueva herramienta `get_anda_survey_info(idno)` con la metadata completa de una encuesta: resumen/abstract, cantidad de variables documentadas, vistas/descargas, términos de confidencialidad y contacto para solicitar microdatos restringidos.
- Nueva herramienta `download_anda_microdata(idno)`: da los links directos de descarga de los archivos de microdatos de una encuesta. ANDA pone un formulario de términos de uso de un clic ("solo fines estadísticos/investigación, no reidentificar encuestados, citar la fuente") antes de mostrar los links de descarga — el tool automatiza ese paso (GET para el token CSRF, POST aceptando) para descubrirlos. Los links en sí no necesitan sesión ni cookie una vez conocidos, así que el tool devuelve las URLs en vez de intentar mandar el archivo (son ZIPs de varios MB con `.sav` de SPSS adentro, demasiado grandes para un resultado de tool).
- **Búsqueda corregida**: la búsqueda propia de ANDA (`sk`) es floja — un query como "ENESEM" también traía REEM, índices de precios, etc. Ahora se trae un lote más grande de candidatos y se filtra localmente para que las palabras del query realmente aparezcan, mismo enfoque que ya usa `search_tramites`.
- Nuevo `helpers/anda_client.py` siguiendo el mismo patrón que `gobec_client.py`. Nueva entrada `anda`/`anda_site` en `helpers/env_config.py` (con override por variable de entorno, igual que las demás fuentes).
- Actualicé `list_capabilities` y el README para que la fuente y las tools nuevas sean descubribles.

## Notas de la implementación
- El parámetro de búsqueda real de la API NADA es `sk`, no `search` ni `q` — lo confirmé probando cuál filtraba de verdad contra la API en vivo.
- El endpoint de detalle (`GET catalog/{idno}`) se busca por **idno** (el identificador string), no por el `id` numérico — devuelve 400 con `{"status":"failed","message":"IDNO-NOT-FOUND"}` si le pasas el numérico.
- El flujo de descarga de microdatos usa el `id` numérico (no el idno), vía `GET/POST catalog/{id}/get-microdata`.
- Probé la codificación de la respuesta preocupado por caracteres mal decodificados que vi en pruebas manuales — resultó ser un artefacto de mi propia terminal, no un bug real: los bytes en crudo (`0xC3 0x8D` para "Í") están correctamente en UTF-8.
- **Verificado que ANDA no tiene el mismo problema de bloqueo regional que `datosabiertos.gob.ec`** — probé el flujo completo (cliente + tools vía MCP) desde una IP real fuera de Latinoamérica (sin VPN) y funciona igual que desde la región.

## Plan de pruebas
- [x] `python -m pytest tests/` — 36 pruebas pasaron (9 nuevas para `anda_client`)
- [x] `ruff check .` en los archivos tocados — sin errores nuevos
- [x] Levanté el servidor local y llamé las tres herramientas vía protocolo MCP real, con resultados reales del catálogo (ej. `search_anda("ENESEM")` trae exactamente las 8 ediciones 2016-2023, sin ruido)
- [x] Repetí la prueba sin VPN, desde una IP de Canadá, para confirmar que no hay restricción geográfica en esta fuente
- [x] Descargué los 7 archivos reales del ENESEM 2023 end-to-end con `download_anda_microdata` y confirmé que cada ZIP es válido y contiene el `.sav` esperado

🤖 Generated with [Claude Code](https://claude.com/claude-code)