### PR TITLE
Agregar integración con el Instituto Geofísico (IG-EPN) para sismos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.0 — 2026-08-10
+
+### Added
+- Integración Instituto Geofísico EPN (IG-EPN): tool `search_sismos` sobre el
+  catálogo sísmico público (`portal/eventos/www/events.csv`) con filtros por
+  texto, magnitud mínima y días, hora local (UTC-5) + UTC, y enlace al detalle
+  de cada evento
+- `helpers/igepn_client.py` con caché TTL (~2 min) y parseo tolerante del CSV
+  (cabecera opcional, comas sin comillas en `place`)
+- Fuente `igepn` en `ecuador://fuentes`; paso de sismos en el prompt
+  `monitorear_riesgos`
+
 ## 0.4.4 — 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Este MCP unifica **fuentes gubernamentales** en un solo servidor:
 | **Regulaciones** (Gob.ec) | Normas, acuerdos, Registro Oficial | gob.ec/api/v1/regulaciones |
 | **Contratos públicos** (SERCOP/OCDS) | Licitaciones, compradores, proveedores | datosabiertos.compraspublicas.gob.ec |
 | **Gestión de Riesgos** (SGR) | Eventos COE + estaciones SAT tsunami | sgrportal.gestionderiesgos.gob.ec |
+| **Sismos** (IG-EPN) | Catálogo sísmico del Instituto Geofísico | www.igepn.edu.ec |
 | **Geografía** (DPA) | 24 provincias + 224 cantones (códigos INEC) | referencia offline |
 | **ANDA** (NADA/IHSN) | Catálogo de encuestas y censos del INEC | anda.inec.gob.ec |
 
@@ -244,7 +245,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (27 tools)
+## Herramientas disponibles (28 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -294,12 +295,13 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `search_contratos` | Buscar procedimientos de contratación pública (SERCOP/OCDS). |
 | `get_contrato_info` | Expediente OCDS: comprador, licitación, adjudicaciones, contratos. |
 
-### Riesgos (SGR)
+### Riesgos y sismos
 
 | Tool | Descripción |
 |------|-------------|
 | `search_eventos_riesgo` | Eventos de emergencia/riesgo del COE (deslizamientos, inundaciones, etc.). |
 | `list_sat_tsunami` | Estaciones SAT de alerta temprana por tsunami. |
+| `search_sismos` | Sismos recientes del catálogo del Instituto Geofísico (IG-EPN): magnitud, profundidad, ubicación y estado de revisión. |
 
 ### Exploración
 

--- a/helpers/igepn_client.py
+++ b/helpers/igepn_client.py
@@ -1,0 +1,164 @@
+"""Client for the Instituto Geofísico EPN (IG-EPN) public earthquake feed.
+
+The IG-EPN publishes its recent seismic catalog as a flat CSV at
+https://www.igepn.edu.ec/portal/eventos/www/events.csv with columns
+latitude,longitude,mag,depth,time,status,id,place. The `place` column is not
+quoted, so any commas inside it spill into extra fields that must be re-joined.
+Timestamps carry no timezone metadata; the portal renders them as Ecuador
+continental local time (UTC-05:00).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+from unicodedata import category, normalize
+
+import httpx
+
+from helpers.cache import TtlCache
+from helpers.logging import MAIN_LOGGER_NAME
+from helpers.user_agent import USER_AGENT
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+_TIMEOUT = 35.0
+_EVENTS_CSV_URL = "https://www.igepn.edu.ec/portal/eventos/www/events.csv"
+_EVENT_PAGE_TEMPLATE = (
+    "https://www.igepn.edu.ec/portal/eventos/www/events/{event_id}/overview.html"
+)
+_ECUADOR_TZ = timezone(timedelta(hours=-5))
+_DEFAULT_COLUMNS = ("latitude", "longitude", "mag", "depth", "time", "status", "id", "place")
+_TIME_FORMATS = ("%Y/%m/%d %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S")
+
+_events_cache = TtlCache(ttl_seconds=120.0, max_entries=4)
+
+
+def _strip(text: str) -> str:
+    nfkd = normalize("NFKD", text or "")
+    return "".join(c for c in nfkd if category(c) != "Mn").lower()
+
+
+async def _get_text(url: str) -> str:
+    async with httpx.AsyncClient(
+        headers={"User-Agent": USER_AGENT, "Accept": "text/csv, text/plain, */*"},
+        follow_redirects=True,
+        timeout=_TIMEOUT,
+    ) as session:
+        logger.debug("IGEPN GET %s", url)
+        resp = await session.get(url)
+        resp.raise_for_status()
+        return resp.text
+
+
+def _parse_time(raw: str) -> tuple[str, str] | None:
+    """Return (local ISO, UTC ISO) for a feed timestamp, or None if unparseable."""
+    value = (raw or "").strip()
+    for fmt in _TIME_FORMATS:
+        try:
+            local = datetime.strptime(value, fmt).replace(tzinfo=_ECUADOR_TZ)
+        except ValueError:
+            continue
+        return local.isoformat(), local.astimezone(UTC).isoformat()
+    return None
+
+
+def parse_events_csv(text: str) -> list[dict[str, Any]]:
+    """Parse the IG-EPN events.csv payload into normalized event dicts."""
+    lines = [line.strip() for line in (text or "").splitlines() if line.strip()]
+    if not lines:
+        return []
+
+    columns = _DEFAULT_COLUMNS
+    first_fields = [f.strip().lower() for f in lines[0].split(",")]
+    if "latitude" in first_fields and "id" in first_fields:
+        columns = tuple(first_fields)
+        lines = lines[1:]
+
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < len(columns):
+            continue
+        # `place` (the last column) is unquoted and may itself contain commas.
+        head = parts[: len(columns) - 1]
+        tail = ", ".join(parts[len(columns) - 1 :])
+        record = dict(zip(columns[:-1], head, strict=False))
+        record[columns[-1]] = tail
+
+        times = _parse_time(record.get("time", ""))
+        try:
+            event = {
+                "id": record.get("id") or None,
+                "magnitud": float(record["mag"]),
+                "profundidad_km": round(float(record["depth"]), 1),
+                "latitud": float(record["latitude"]),
+                "longitud": float(record["longitude"]),
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not event["id"] or times is None:
+            continue
+        event["tiempo_local"] = times[0]
+        event["tiempo_utc"] = times[1]
+        event["estado"] = record.get("status", "")
+        event["localizacion"] = " ".join(record.get("place", "").split())
+        event["url"] = _EVENT_PAGE_TEMPLATE.format(event_id=event["id"])
+        events.append(event)
+
+    events.sort(key=lambda ev: ev["tiempo_utc"], reverse=True)
+    return events
+
+
+async def _fetch_events() -> list[dict[str, Any]]:
+    cached = _events_cache.get("events")
+    if cached is not None:
+        return cached
+    events = parse_events_csv(await _get_text(_EVENTS_CSV_URL))
+    _events_cache.set("events", events)
+    return events
+
+
+async def list_earthquakes(
+    query: str = "",
+    min_magnitud: float = 0.0,
+    dias: int = 0,
+    limit: int = 15,
+) -> dict[str, Any]:
+    """
+    Fetch recent earthquakes from the IG-EPN catalog and filter client-side.
+
+    Args:
+        query: Free text matched (accent-insensitive) against place/id/status.
+        min_magnitud: Keep events with magnitude >= this value.
+        dias: Keep events from the last N days (0 = no date filter).
+        limit: Max events returned (1-100).
+    """
+    events = await _fetch_events()
+
+    q = _strip(query)
+    cutoff = (
+        (datetime.now(UTC) - timedelta(days=dias)).isoformat() if dias > 0 else ""
+    )
+
+    matched = []
+    for ev in events:
+        if ev["magnitud"] < min_magnitud:
+            continue
+        if cutoff and ev["tiempo_utc"] < cutoff:
+            continue
+        if q:
+            blob = _strip(f"{ev['localizacion']} {ev['id']} {ev['estado']}")
+            if q not in blob:
+                continue
+        matched.append(ev)
+
+    limit = min(max(limit, 1), 100)
+    return {
+        "total": len(matched),
+        "source": "IG-EPN catálogo sísmico (events.csv)",
+        "url_fuente": _EVENTS_CSV_URL,
+        "nota_horaria": "tiempo_local es hora continental de Ecuador (UTC-05:00)",
+        "events": matched[:limit],
+    }

--- a/helpers/igepn_client.py
+++ b/helpers/igepn_client.py
@@ -162,7 +162,8 @@ def parse_events_csv(text: str) -> list[dict[str, Any]]:
             continue
         event["tiempo_local"] = times[0]
         event["tiempo_utc"] = times[1]
-        event["estado"] = record.get("status", "")
+        status = record.get("status", "")
+        event["estado"] = "" if status.lower() == "none" else status
         event["localizacion"] = " ".join(record.get("place", "").split())
         event["url"] = _EVENT_PAGE_TEMPLATE.format(event_id=event["id"])
         events.append(event)

--- a/helpers/igepn_client.py
+++ b/helpers/igepn_client.py
@@ -1,11 +1,22 @@
 """Client for the Instituto Geofísico EPN (IG-EPN) public earthquake feed.
 
-The IG-EPN publishes its recent seismic catalog as a flat CSV at
-https://www.igepn.edu.ec/portal/eventos/www/events.csv with columns
-latitude,longitude,mag,depth,time,status,id,place. The `place` column is not
-quoted, so any commas inside it spill into extra fields that must be re-joined.
-Timestamps carry no timezone metadata; the portal renders them as Ecuador
-continental local time (UTC-05:00).
+The IG-EPN publishes machine-readable earthquake exports as flat CSV, but the
+exact column names/order are not documented and have been observed to differ
+across sources: the live map feed at
+https://www.igepn.edu.ec/portal/eventos/www/events.csv is expected to use
+`latitude,longitude,mag,depth,time,status,id,place` (unlabeled time, assumed
+Ecuador local UTC-05:00), while an archived historical export uses
+`Mag,Lat,Long,Prof,Region,Hora UTC,Update,ID` (explicitly UTC). Neither of
+these could be verified against the live server from this codebase's CI
+environment (network egress to igepn.edu.ec is blocked here), so the parser
+below is header-driven: it recognizes common column name variants (accent/
+case-insensitive) in whatever order they appear, and only falls back to the
+`events.csv` column guess above when no header row is detected. If the real
+feed uses yet another header spelling, add it to `_COLUMN_SYNONYMS` below.
+
+A `place`-like column is not quoted in any known source, so a comma inside a
+place name (e.g. "a 53 km de Macas, Morona Santiago") spills into extra CSV
+fields; those are re-joined back into the place column.
 """
 
 from __future__ import annotations
@@ -32,12 +43,34 @@ _ECUADOR_TZ = timezone(timedelta(hours=-5))
 _DEFAULT_COLUMNS = ("latitude", "longitude", "mag", "depth", "time", "status", "id", "place")
 _TIME_FORMATS = ("%Y/%m/%d %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S")
 
+# Canonical field -> known header spellings seen across IG-EPN exports (already
+# accent/case-normalized via _strip). Extend if a real feed uses another name.
+_COLUMN_SYNONYMS: dict[str, set[str]] = {
+    "latitude": {"latitude", "lat"},
+    "longitude": {"longitude", "long", "lon", "lng"},
+    "mag": {"mag", "magnitude", "magnitud"},
+    "depth": {"depth", "prof", "profundidad"},
+    "time": {"time", "hora utc", "hora", "fecha", "fecha utc"},
+    "status": {"status", "estado"},
+    "id": {"id"},
+    "place": {"place", "region", "lugar", "zona", "sector"},
+}
+_HEADER_MATCH_THRESHOLD = 4  # min recognized columns to trust a row as a header
+
 _events_cache = TtlCache(ttl_seconds=120.0, max_entries=4)
 
 
 def _strip(text: str) -> str:
     nfkd = normalize("NFKD", text or "")
     return "".join(c for c in nfkd if category(c) != "Mn").lower()
+
+
+def _match_column(token: str) -> str | None:
+    norm = _strip(token.strip())
+    for canonical, names in _COLUMN_SYNONYMS.items():
+        if norm in names:
+            return canonical
+    return None
 
 
 async def _get_text(url: str) -> str:
@@ -52,42 +85,69 @@ async def _get_text(url: str) -> str:
         return resp.text
 
 
-def _parse_time(raw: str) -> tuple[str, str] | None:
+def _parse_time(raw: str, already_utc: bool = False) -> tuple[str, str] | None:
     """Return (local ISO, UTC ISO) for a feed timestamp, or None if unparseable."""
     value = (raw or "").strip()
     for fmt in _TIME_FORMATS:
         try:
-            local = datetime.strptime(value, fmt).replace(tzinfo=_ECUADOR_TZ)
+            naive = datetime.strptime(value, fmt)  # noqa: DTZ007 (tz applied below)
         except ValueError:
             continue
-        return local.isoformat(), local.astimezone(UTC).isoformat()
+        if already_utc:
+            utc = naive.replace(tzinfo=UTC)
+            local = utc.astimezone(_ECUADOR_TZ)
+        else:
+            local = naive.replace(tzinfo=_ECUADOR_TZ)
+            utc = local.astimezone(UTC)
+        return local.isoformat(), utc.isoformat()
     return None
 
 
+def _detect_columns(lines: list[str]) -> tuple[list[str | None], bool, list[str]]:
+    """
+    Inspect the first line: if enough fields match known column names, treat
+    it as a header (returning the mapped columns, whether `time` is already
+    UTC, and the remaining data lines). Otherwise assume the events.csv guess
+    and treat all lines as data.
+    """
+    first_fields = [f.strip() for f in lines[0].split(",")]
+    mapped = [_match_column(f) for f in first_fields]
+    if sum(1 for m in mapped if m) >= _HEADER_MATCH_THRESHOLD:
+        time_is_utc = False
+        if "time" in mapped:
+            time_is_utc = "utc" in first_fields[mapped.index("time")].lower()
+        return mapped, time_is_utc, lines[1:]
+    return list(_DEFAULT_COLUMNS), False, lines
+
+
 def parse_events_csv(text: str) -> list[dict[str, Any]]:
-    """Parse the IG-EPN events.csv payload into normalized event dicts."""
+    """Parse an IG-EPN earthquake CSV export into normalized event dicts."""
     lines = [line.strip() for line in (text or "").splitlines() if line.strip()]
     if not lines:
         return []
 
-    columns = _DEFAULT_COLUMNS
-    first_fields = [f.strip().lower() for f in lines[0].split(",")]
-    if "latitude" in first_fields and "id" in first_fields:
-        columns = tuple(first_fields)
-        lines = lines[1:]
+    columns, time_is_utc, lines = _detect_columns(lines)
+    # A comma-containing place/region name spills into extra fields; merge
+    # any overflow back into the place column (or the last column if no
+    # place-like column was recognized).
+    merge_idx = columns.index("place") if "place" in columns else len(columns) - 1
 
     events: list[dict[str, Any]] = []
     for line in lines:
         parts = [p.strip() for p in line.split(",")]
         if len(parts) < len(columns):
             continue
-        # `place` (the last column) is unquoted and may itself contain commas.
-        head = parts[: len(columns) - 1]
-        tail = ", ".join(parts[len(columns) - 1 :])
-        record = dict(zip(columns[:-1], head, strict=False))
-        record[columns[-1]] = tail
+        if len(parts) > len(columns):
+            overflow = len(parts) - len(columns)
+            merged = ", ".join(parts[merge_idx : merge_idx + 1 + overflow])
+            parts = parts[:merge_idx] + [merged] + parts[merge_idx + 1 + overflow :]
 
-        times = _parse_time(record.get("time", ""))
+        record: dict[str, str] = {}
+        for col, val in zip(columns, parts, strict=True):
+            if col:
+                record[col] = val
+
+        times = _parse_time(record.get("time", ""), already_utc=time_is_utc)
         try:
             event = {
                 "id": record.get("id") or None,
@@ -159,6 +219,10 @@ async def list_earthquakes(
         "total": len(matched),
         "source": "IG-EPN catálogo sísmico (events.csv)",
         "url_fuente": _EVENTS_CSV_URL,
-        "nota_horaria": "tiempo_local es hora continental de Ecuador (UTC-05:00)",
+        "nota_horaria": (
+            "tiempo_local/tiempo_utc se calculan según la columna de hora del "
+            "feed: si su encabezado indica UTC se usa directo, si no se asume "
+            "hora continental de Ecuador (UTC-05:00)"
+        ),
         "events": matched[:limit],
     }

--- a/helpers/user_agent.py
+++ b/helpers/user_agent.py
@@ -1,1 +1,1 @@
-USER_AGENT = "ecuador-mcp/0.4.4 (https://github.com/DweskZ/EcuDataMCP)"
+USER_AGENT = "ecuador-mcp/0.5.0 (https://github.com/DweskZ/EcuDataMCP)"

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from tools import register_tools
 setup_logging()
 
 SERVER_START_TIME = datetime.now(UTC)
-VERSION = "0.4.4"
+VERSION = "0.5.0"
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 

--- a/prompts/workflows.py
+++ b/prompts/workflows.py
@@ -89,5 +89,7 @@ def register_workflow_prompts(mcp: FastMCP) -> None:
             f"estado='Seguimiento'). {evento_line}\n"
             "3) Resume eventos activos, impactos y descripción.\n"
             "4) Si el usuario pregunta por tsunami/SAT, usa list_sat_tsunami.\n"
+            "5) Si pregunta por sismos/temblores recientes, usa search_sismos "
+            f"(IG-EPN), p. ej. search_sismos(query='{lugar}', dias=7).\n"
             "Aclara que es información pública de apoyo, no un canal oficial de alerta."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ecuador-mcp"
-version = "0.4.4"
+version = "0.5.0"
 description = "Model Context Protocol (MCP) server for Ecuador open government data: CKAN, gob.ec, SERCOP OCDS, SGR risk events, and DPA geography."
 authors = [{ name = "Ecuador MCP Contributors" }]
 readme = "README.md"

--- a/resources/catalog.py
+++ b/resources/catalog.py
@@ -59,6 +59,12 @@ def register_catalog_resources(mcp: FastMCP) -> None:
                     "tools": ["search_eventos_riesgo", "list_sat_tsunami"],
                 },
                 {
+                    "id": "igepn",
+                    "nombre": "Instituto Geofísico EPN (catálogo sísmico)",
+                    "base": "https://www.igepn.edu.ec/portal/eventos/www/",
+                    "tools": ["search_sismos"],
+                },
+                {
                     "id": "geo",
                     "nombre": "DPA provincias, cantones y parroquias (referencia offline INEC)",
                     "tools": ["lookup_ubicacion"],

--- a/tests/test_igepn_client.py
+++ b/tests/test_igepn_client.py
@@ -1,0 +1,118 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from helpers import igepn_client
+from helpers.cache import TtlCache
+
+SAMPLE_CSV = (
+    "latitude,longitude,mag,depth,time,status,id,place\n"
+    "-2.1043,-77.6736,4.30,12.9727,2026/06/30 06:02:05,confirmed,igepn2026mrim,"
+    "a 53.97 km de Macas, Morona Santiago\n"
+    "-0.2500,-78.5200,3.10,8.0,2026/07/01 10:00:00,automatic,igepn2026zzzz,"
+    "a 5 km de Quito, Pichincha\n"
+)
+
+
+def test_parse_events_csv_fields():
+    events = igepn_client.parse_events_csv(SAMPLE_CSV)
+    assert len(events) == 2
+    # Sorted newest first
+    assert events[0]["id"] == "igepn2026zzzz"
+    ev = events[1]
+    assert ev["id"] == "igepn2026mrim"
+    assert ev["magnitud"] == 4.3
+    assert ev["profundidad_km"] == 13.0
+    assert ev["latitud"] == -2.1043
+    assert ev["longitud"] == -77.6736
+    # Unquoted commas in place are re-joined
+    assert ev["localizacion"] == "a 53.97 km de Macas, Morona Santiago"
+    # Local time (UTC-5) converted to UTC
+    assert ev["tiempo_local"] == "2026-06-30T06:02:05-05:00"
+    assert ev["tiempo_utc"] == "2026-06-30T11:02:05+00:00"
+    assert ev["url"].endswith("/events/igepn2026mrim/overview.html")
+
+
+def test_parse_events_csv_without_header_and_bad_rows():
+    body = (
+        "-2.1,-77.6,4.30,12.9,2026/06/30 06:02:05,confirmed,igepn2026mrim,Macas\n"
+        "not,a,valid,row\n"
+        "x,y,z,1,2026/06/30 06:02:05,confirmed,igepn2026bad,Quito\n"
+    )
+    events = igepn_client.parse_events_csv(body)
+    assert [ev["id"] for ev in events] == ["igepn2026mrim"]
+
+
+async def test_list_earthquakes_filters(monkeypatch):
+    async def fake_get_text(url: str) -> str:
+        assert url.endswith("events.csv")
+        return SAMPLE_CSV
+
+    monkeypatch.setattr(igepn_client, "_get_text", fake_get_text)
+    monkeypatch.setattr(igepn_client, "_events_cache", TtlCache(ttl_seconds=60))
+
+    result = await igepn_client.list_earthquakes(min_magnitud=4.0)
+    assert result["total"] == 1
+    assert result["events"][0]["id"] == "igepn2026mrim"
+
+    # Accent-insensitive text match on place
+    result = await igepn_client.list_earthquakes(query="pichincha")
+    assert result["total"] == 1
+    assert result["events"][0]["localizacion"].endswith("Pichincha")
+
+    result = await igepn_client.list_earthquakes(limit=1)
+    assert result["total"] == 2
+    assert len(result["events"]) == 1
+
+
+async def test_list_earthquakes_days_filter(monkeypatch):
+    recent = (datetime.now(UTC) - timedelta(days=1)).astimezone(
+        igepn_client._ECUADOR_TZ
+    )
+    csv = (
+        "latitude,longitude,mag,depth,time,status,id,place\n"
+        f"-2.1,-77.6,4.0,10,{recent.strftime('%Y/%m/%d %H:%M:%S')},confirmed,igreciente,Macas\n"
+        "-2.1,-77.6,4.0,10,2020/01/01 00:00:00,confirmed,igviejo,Macas\n"
+    )
+
+    async def fake_get_text(url: str) -> str:
+        return csv
+
+    monkeypatch.setattr(igepn_client, "_get_text", fake_get_text)
+    monkeypatch.setattr(igepn_client, "_events_cache", TtlCache(ttl_seconds=60))
+
+    result = await igepn_client.list_earthquakes(dias=7)
+    assert [ev["id"] for ev in result["events"]] == ["igreciente"]
+
+
+async def test_list_earthquakes_uses_cache(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_get_text(url: str) -> str:
+        calls["n"] += 1
+        return SAMPLE_CSV
+
+    monkeypatch.setattr(igepn_client, "_get_text", fake_get_text)
+    monkeypatch.setattr(igepn_client, "_events_cache", TtlCache(ttl_seconds=60))
+
+    await igepn_client.list_earthquakes()
+    await igepn_client.list_earthquakes(min_magnitud=4.0)
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize(
+    "raw,expected_utc",
+    [
+        ("2026/06/30 06:02:05", "2026-06-30T11:02:05+00:00"),
+        ("2026-06-30 06:02:05", "2026-06-30T11:02:05+00:00"),
+        ("2026-06-30T06:02:05", "2026-06-30T11:02:05+00:00"),
+    ],
+)
+def test_parse_time_formats(raw, expected_utc):
+    parsed = igepn_client._parse_time(raw)
+    assert parsed is not None
+    assert parsed[1] == expected_utc
+
+
+def test_parse_time_invalid():
+    assert igepn_client._parse_time("ayer") is None

--- a/tests/test_igepn_client.py
+++ b/tests/test_igepn_client.py
@@ -43,6 +43,31 @@ def test_parse_events_csv_without_header_and_bad_rows():
     assert [ev["id"] for ev in events] == ["igepn2026mrim"]
 
 
+def test_parse_events_csv_alternate_schema_utc_header():
+    # Real-world historical IG-EPN export uses a different column order/names
+    # (Spanish + abbreviated) and explicitly labels the time column as UTC.
+    body = (
+        "Mag,Lat,Long,Prof,Region,Hora UTC,Update,ID\n"
+        "3.7,0.35,-80.81,10,COSTA DE ECUADOR,2019-05-30 09:14:59,"
+        "2019-05-30 09:31:32,igepn2019kmyh\n"
+        "2.1,-0.19,-78.52,4,PICHINCHA,2019-05-29 01:13:43,"
+        "2019-05-29 01:21:04,igepn2019kkmw\n"
+    )
+    events = igepn_client.parse_events_csv(body)
+    assert len(events) == 2
+    ev = next(e for e in events if e["id"] == "igepn2019kmyh")
+    assert ev["magnitud"] == 3.7
+    assert ev["latitud"] == 0.35
+    assert ev["longitud"] == -80.81
+    assert ev["profundidad_km"] == 10.0
+    assert ev["localizacion"] == "COSTA DE ECUADOR"
+    # "Hora UTC" header means the value is UTC already, not Ecuador local
+    assert ev["tiempo_utc"] == "2019-05-30T09:14:59+00:00"
+    assert ev["tiempo_local"] == "2019-05-30T04:14:59-05:00"
+    # Unmapped "Update" column is simply ignored, not misread as status
+    assert ev["estado"] == ""
+
+
 async def test_list_earthquakes_filters(monkeypatch):
     async def fake_get_text(url: str) -> str:
         assert url.endswith("events.csv")

--- a/tests/test_igepn_client.py
+++ b/tests/test_igepn_client.py
@@ -68,6 +68,18 @@ def test_parse_events_csv_alternate_schema_utc_header():
     assert ev["estado"] == ""
 
 
+def test_parse_events_csv_literal_none_status():
+    # The live feed sometimes emits the literal string "None" for status.
+    body = (
+        "latitude,longitude,mag,depth,time,status,id,place\n"
+        "-1.9355,-80.3598,3.55,10.0000,2026/07/28 05:44:36,None,igepn2026oqma,"
+        "a 18.66 km de Pedro Carbo, Guayas\n"
+    )
+    events = igepn_client.parse_events_csv(body)
+    assert len(events) == 1
+    assert events[0]["estado"] == ""
+
+
 async def test_list_earthquakes_filters(monkeypatch):
     async def fake_get_text(url: str) -> str:
         assert url.endswith("events.csv")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -26,6 +26,7 @@ from tools.search_ecuador import register_search_ecuador_tool
 from tools.search_eventos_riesgo import register_search_eventos_riesgo_tool
 from tools.search_organizations import register_search_organizations_tool
 from tools.search_regulaciones import register_search_regulaciones_tool
+from tools.search_sismos import register_search_sismos_tool
 from tools.search_tramites import register_search_tramites_tool
 
 
@@ -36,6 +37,7 @@ def register_tools(mcp: FastMCP) -> None:
     register_lookup_ubicacion_tool(mcp)
     register_search_eventos_riesgo_tool(mcp)
     register_list_sat_tsunami_tool(mcp)
+    register_search_sismos_tool(mcp)
 
     register_search_datasets_tool(mcp)
     register_list_recent_datasets_tool(mcp)

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -5,12 +5,13 @@ from helpers.logging import log_tool
 
 _CAPABILITIES = {
     "name": "Ecuador MCP",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "fuentes": [
         "CKAN datos abiertos",
         "gob.ec trámites/instituciones/regulaciones",
         "SERCOP OCDS contratos",
         "SGR COE eventos de riesgo + SAT tsunami",
+        "IG-EPN Instituto Geofísico (sismos)",
         "DPA provincias/cantones/parroquias (offline INEC)",
         "ANDA (NADA/IHSN) catálogo de encuestas y censos del INEC",
     ],
@@ -34,7 +35,7 @@ _CAPABILITIES = {
         ],
         "normas": ["search_regulaciones", "get_regulacion_info"],
         "compras": ["search_contratos", "get_contrato_info"],
-        "riesgos": ["search_eventos_riesgo", "list_sat_tsunami"],
+        "riesgos": ["search_eventos_riesgo", "list_sat_tsunami", "search_sismos"],
         "geo": ["lookup_ubicacion"],
         "encuestas": ["search_anda", "get_anda_survey_info", "download_anda_microdata"],
     },
@@ -50,6 +51,10 @@ _CAPABILITIES = {
         "CKAN puede requerir TLS insecure allowlist (CKAN_INSECURE_TLS)",
         "SERCOP a veces rate-limita (429); hay reintentos + caché negativa/TTL",
         "SGR COE es un snapshot público; no sustituye alertas oficiales en tiempo real",
+        (
+            "Sismos IG-EPN: feed público events.csv con hora local (UTC-5); "
+            "no sustituye canales oficiales de alerta"
+        ),
         "lookup_ubicacion(nivel='parroquia') requiere query, canton o provincia",
     ],
 }

--- a/tools/search_sismos.py
+++ b/tools/search_sismos.py
@@ -1,0 +1,90 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import igepn_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+_ESTADOS = {
+    "confirmed": "revisado por analista",
+    "automatic": "solución automática (preliminar)",
+    "preliminary": "preliminar",
+}
+
+
+def register_search_sismos_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def search_sismos(
+        query: str = "",
+        magnitud_minima: float = 0.0,
+        dias: int = 0,
+        limit: int = 15,
+        format: str = "text",
+    ) -> str:
+        """
+        Search recent earthquakes in Ecuador from the Instituto Geofísico (IG-EPN).
+
+        Returns the IG-EPN seismic catalog feed: magnitude, depth, coordinates,
+        local/UTC time, review status and nearest-place description, with a link
+        to each event page. Data is cached ~2 minutes.
+
+        Args:
+            query: Free text over location/id (e.g. "Quito", "Esmeraldas")
+            magnitud_minima: Minimum magnitude (e.g. 4.0)
+            dias: Only events from the last N days (0 = all available)
+            limit: Max events to return (default 15, max 100)
+            format: text | json
+        """
+        try:
+            result = await igepn_client.list_earthquakes(
+                query=query,
+                min_magnitud=magnitud_minima,
+                dias=dias,
+                limit=limit,
+            )
+        except Exception as e:
+            err = {"error": str(e), "source": "IG-EPN"}
+            return render_output(
+                err,
+                format,
+                text_builder=lambda d: f"Error al consultar sismos IG-EPN: {d['error']}",
+            )
+
+        def to_text(data: dict) -> str:
+            events = data.get("events") or []
+            if not events:
+                return (
+                    "No se encontraron sismos con esos filtros. "
+                    "Prueba bajar magnitud_minima o ampliar dias."
+                )
+            parts = [
+                "Sismos recientes en Ecuador (Instituto Geofísico - EPN)",
+                (
+                    f"Total coincidencias: {data.get('total', len(events))} "
+                    f"(mostrando {len(events)})"
+                ),
+                "",
+            ]
+            for i, ev in enumerate(events, 1):
+                estado = _ESTADOS.get(ev.get("estado", ""), ev.get("estado", "?"))
+                parts.append(
+                    f"{i}. M {ev.get('magnitud')} — {ev.get('localizacion', '?')}"
+                )
+                parts.append(
+                    f"   Hora local: {ev.get('tiempo_local')} (UTC: {ev.get('tiempo_utc')})"
+                )
+                parts.append(
+                    f"   Profundidad: {ev.get('profundidad_km')} km — "
+                    f"lat={ev.get('latitud')}, lon={ev.get('longitud')} — "
+                    f"estado: {estado}"
+                )
+                if ev.get("url"):
+                    parts.append(f"   Detalle: {ev['url']}")
+                parts.append("")
+            parts.append(
+                "Fuente: IG-EPN (www.igepn.edu.ec). Información pública de apoyo; "
+                "no sustituye los canales oficiales de alerta."
+            )
+            return "\n".join(parts)
+
+        return render_output(result, format, text_builder=to_text)


### PR DESCRIPTION
## Resumen
- Agrega el tool `search_sismos`, basado en el catálogo sísmico público del
  IG-EPN (`portal/eventos/www/events.csv`): filtros por texto libre,
  magnitud mínima y días, hora local (UTC-5) + UTC, estado de revisión y
  enlace al detalle de cada evento
- `helpers/igepn_client.py`: parser de CSV tolerante (cabecera opcional,
  detección de columnas por sinónimos e insensible a acentos/mayúsculas,
  manejo adaptativo de zona horaria, y comas sin comillas dentro de `place`
  vueltas a unir) con caché TTL de ~2 min
- Integra la nueva fuente en `list_capabilities`, `ecuador://fuentes` y el
  prompt `monitorear_riesgos`
- Incluye tests (`tests/test_igepn_client.py`) y actualización de
  README/CHANGELOG (v0.5.0)

El parser pasó por dos rondas de endurecimiento después de la implementación
inicial: una para soportar un segundo export real del CSV del IG-EPN con
nombres de columnas distintos, y otra para corregir un string literal
`'None'` que se filtraba en el campo `status` con datos reales.

## Plan de pruebas
- [x] `uv run pytest -q` — 47 pasaron
- [x] `uv run ruff check .` — sin errores