### PR TITLE
Integración Superintendencia de Compañías: directorio, ranking financiero, auditores externos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ env/
 *.lock
 .DS_Store
 Thumbs.db
+
+# Built locally by scripts/build_supercias_financials_db.py -- large (~cientos
+# de MB), refreshed periodically, not static reference data like helpers/data/.
+/data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.5.4 — 2026-08-16
+
+Integración completa de la Superintendencia de Compañías (Supercías):
+directorio, ranking financiero, y registro de auditores externos.
+
+### Added
+- **Directorio de compañías** (`search_companias`/`get_compania_info`):
+  el directorio nacional de compañías (226k+, actualizado a diario) —
+  situación legal, representante legal, capital suscrito, CIIU, dirección.
+  `helpers/supercias_client.py` parsea el export Excel del portal con
+  `ElementTree.iterparse` (el `<dimension>` del archivo viene mal
+  declarado y rompe el modo `read_only` de openpyxl), cacheado en memoria
+  6h (parseo CPU-bound corre en `asyncio.to_thread` para no bloquear el
+  event loop con clientes HTTP concurrentes).
+- **Ranking financiero** (`search_ranking`/`get_financials`): segundo
+  dataset de Supercías (`bi_ranking.csv`, ~356 MB / ~9M filas) — ingresos,
+  activos, patrimonio y ~38 ratios financieros por compañía y año fiscal,
+  derivados de balances reales. `helpers/supercias_financials.py` consulta
+  un SQLite local construido de antemano por
+  `scripts/build_supercias_financials_db.py` (recortado a los últimos 5
+  años fiscales, autoajustable), con su propia tabla `companias`
+  (expediente, ruc, nombre) cargada desde `bi_compania.csv` — resuelve
+  nombre/RUC sin depender del directorio, que se cachea y refresca por
+  separado. El build es atómico: construye en `<db>.building`, verifica
+  integridad y columnas requeridas, y recién entonces reemplaza la base
+  que ya funciona — un build fallido nunca la deja sin datos.
+  `helpers/tls.py` gana `legacy_cipher_context()` para el handshake TLS de
+  `appscvsmovil.supercias.gob.ec` (host distinto del directorio, exige un
+  mínimo de cifrado que OpenSSL 3 rechaza por defecto — mecanismo separado
+  del fallback de certificados vencidos).
+- **Registro de auditores externos** (`search_auditores`/`get_auditor_info`):
+  tercer dataset de Supercías, el registro de firmas/personas autorizadas
+  para actuar como auditores externos (1,447 filas, ~190 KB, mismo host y
+  patrón de refresco diario que el directorio). `_parse_xlsx` generalizado
+  para aceptar `header_markers` configurables, ya que este export usa
+  `IDENTIFICACION` como columna de identificación en vez de `RUC`.
+
 ## 0.5.1 — 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Este MCP unifica **fuentes gubernamentales** en un solo servidor:
 | **Sismos** (IG-EPN) | Catálogo sísmico del Instituto Geofísico | www.igepn.edu.ec |
 | **Geografía** (DPA) | 24 provincias + 224 cantones (códigos INEC) | referencia offline |
 | **ANDA** (NADA/IHSN) | Catálogo de encuestas y censos del INEC | anda.inec.gob.ec |
+| **Supercías** | Directorio de compañías (226k+): representante legal, capital, CIIU | mercadodevalores.supercias.gob.ec |
+| **Supercías Ranking** | Financieros por balance (ingresos, activos, ROE, ~38 ratios), últimos años; requiere build local | appscvsmovil.supercias.gob.ec |
 
 **Sin API key. Sin restricciones de acceso. 100% datos públicos.**
 
@@ -209,6 +211,14 @@ MCP_PORT=8007 LOG_LEVEL=DEBUG docker compose up -d
 docker compose down
 ```
 
+Los datos financieros de Supercías (`search_ranking`/`get_financials`) no
+se descargan solos ni bajo Docker — corré el build script dentro del
+contenedor, contra el volumen persistente `supercias_data:/app/data`:
+
+```bash
+docker compose exec mcp uv run python scripts/build_supercias_financials_db.py
+```
+
 ### Instalación manual
 
 Requiere Python 3.11+ y [uv](https://docs.astral.sh/uv/).
@@ -243,9 +253,25 @@ Stdio local:
 uv run python main.py --transport stdio
 ```
 
+**Opcional — datos financieros de Supercías** (`search_ranking`/`get_financials`):
+a diferencia del resto de fuentes, esto no se descarga solo. Corre una vez
+antes de usarlos (tarda varios minutos, descarga ~356 MB):
+
+```bash
+uv run python scripts/build_supercias_financials_db.py
+```
+
+Guarda `data/supercias_financials.sqlite3` (gitignored). Repetir cuando
+pase de una semana — los tools avisan si la base está vieja o no existe.
+
+Si el script falla al descargar `bi_ranking.csv`, ver la nota sobre
+geografía de la conexión en la sección
+["Problema conocido"](#problema-conocido-el-portal-de-datos-abiertos-a-veces-bloquea-conexiones)
+más abajo.
+
 ---
 
-## Herramientas disponibles (28 tools)
+## Herramientas disponibles (34 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -285,6 +311,17 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `search_anda` | Buscar encuestas y censos en el catálogo ANDA del INEC (NADA/IHSN). Indica si cada encuesta tiene microdatos descargables. |
 | `get_anda_survey_info` | Metadata completa de una encuesta ANDA: resumen, variables, confidencialidad y contacto. |
 | `download_anda_microdata` | Links directos de descarga de los archivos de microdatos de una encuesta ANDA. |
+
+### Compañías (Supercías)
+
+| Tool | Descripción |
+|------|-------------|
+| `search_companias` | Buscar en el directorio de compañías de la Superintendencia de Compañías (226k+, por nombre/RUC, provincia, situación legal). |
+| `get_compania_info` | Ficha completa de una compañía por RUC: representante legal, capital suscrito, CIIU, dirección. |
+| `search_ranking` | Rankear/filtrar compañías por indicadores financieros (año, CIIU, cualquier columna) — requiere `scripts/build_supercias_financials_db.py` corrido de antemano. |
+| `get_financials` | Historial financiero de una compañía por expediente o RUC: ingresos, activos, patrimonio, ~38 ratios (liquidez, endeudamiento, rentabilidad), últimos años cacheados. |
+| `search_auditores` | Buscar en el registro de auditores externos autorizados (1,447 firmas/personas, por nombre o identificación, provincia). |
+| `get_auditor_info` | Ficha completa de un auditor externo por identificación: resolución de autorización, nacionalidad, dirección, contacto. |
 
 ### Regulaciones y contratos
 
@@ -358,6 +395,18 @@ En nuestras pruebas:
 Las herramientas de trámites e instituciones (`search_tramites`, `list_instituciones`, `get_institucion_info`, etc.) usan otro portal (`gob.ec`) y no tienen este problema.
 
 **Si ves errores 403 en las herramientas de Datos Abiertos:** intenta correr el servidor desde una conexión (por ejemplo, una VPN) con salida en algún país de Latinoamérica.
+
+**Nota — Supercías (`search_ranking`/`get_financials`):** aparte del problema
+de cifrado TLS que ya maneja `legacy_cipher_context()`
+(`appscvsmovil.supercias.gob.ec` exige un mínimo de cifrado que OpenSSL 3
+rechaza por defecto), este host parece comportarse igual que
+`datosabiertos.gob.ec` en cuanto a geografía de la conexión. Si
+`scripts/build_supercias_financials_db.py` falla incluso con el fix de
+cifrado aplicado, probá correrlo también desde una conexión con salida en
+Latinoamérica antes de asumir que es otro problema — no confirmado de forma
+exhaustiva (el fix de cifrado sí resolvió la conexión en las pruebas de esta
+sesión, corriendo desde una IP de la región), pero vale la pena descartarlo
+primero si falla desde otra región.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    volumes:
+      # Persists data/supercias_financials.sqlite3 across container
+      # recreates -- without this, every redeploy loses it and
+      # search_ranking/get_financials go back to "run the build script"
+      # until someone re-runs scripts/build_supercias_financials_db.py.
+      - supercias_data:/app/data
+
+volumes:
+  supercias_data:

--- a/helpers/supercias_client.py
+++ b/helpers/supercias_client.py
@@ -1,0 +1,578 @@
+"""Client for the Superintendencia de Compañías, Valores y Seguros company registry.
+
+Supercías publishes the full "Directorio de Companias" (226k+ companies) as a
+single static Excel export, refreshed daily, with no auth or pagination
+needed:
+https://mercadodevalores.supercias.gob.ec/reportes/excel/directorio_companias.xlsx
+
+That file (~35 MB) can't be parsed with openpyxl's normal `read_only=True`
+streaming mode: the worksheet's `<dimension>` tag is wrong (it declares only
+"A1" even though the sheet has 226k+ rows), which makes openpyxl's read-only
+iterator stop after a single row. A full (non-read-only) load works but takes
+roughly a minute for a file this size. Instead, `_parse_xlsx` streams the
+worksheet XML directly with `ElementTree.iterparse`, which is correct
+regardless of the bad dimension tag and several times faster.
+
+The export also has a few title/metadata rows (report name, row count,
+generation timestamp) before the real header row, so the header is detected
+by content — a row containing both "RUC" and "NOMBRE" once normalized — not
+assumed to be a fixed row number. The worksheet path itself is resolved from
+`xl/workbook.xml`'s sheet relationships rather than assumed to be
+`sheet1.xml`, so an export that ever gains a second/leading sheet doesn't
+silently get parsed against the wrong one.
+
+Because parsing 226k rows takes several seconds even with the fast path, the
+full parsed table is cached in memory (see `_companias_cache`) rather than
+re-fetched per call, guarded by `_fetch_lock` so concurrent callers don't
+independently download+parse the same ~35 MB file. That cache holds the
+entire registry as one row list plus precomputed search indexes, which is a
+non-trivial amount of memory (roughly a few hundred MB) — acceptable since
+it's built lazily on first use, not at server startup, but worth knowing if
+this process runs somewhere memory-constrained.
+
+The same host also publishes a second, much smaller export: the registry of
+firms/individuals authorized to act as external auditors (~190 KB / 1,447
+rows). Same title-rows-before-header quirk, same parsing approach, but a
+different id column ("IDENTIFICACION" instead of "RUC") — see
+`_fetch_auditores`/`search_auditores`/`get_auditor_info` below. Small enough
+that no memory tradeoff worth documenting applies to it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import re
+import zipfile
+from typing import Any
+from unicodedata import category, normalize
+from xml.etree import ElementTree as ET
+
+import httpx
+
+from helpers.cache import TtlCache
+from helpers.logging import MAIN_LOGGER_NAME
+from helpers.tls import should_retry_insecure
+from helpers.user_agent import USER_AGENT
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+_EXCEL_URL = (
+    "https://mercadodevalores.supercias.gob.ec/reportes/excel/directorio_companias.xlsx"
+)
+_DOWNLOAD_TIMEOUT = 90.0
+# The real file is ~35 MB; this is a safety ceiling, not the expected size.
+_MAX_DOWNLOAD_BYTES = 80 * 1024 * 1024
+_HEADER_SCAN_LIMIT = 20
+_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+_REL_NS = "{http://schemas.openxmlformats.org/package/2006/relationships}"
+_R_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
+
+# Refreshed daily upstream; a few hours balances staleness against the cost
+# of re-downloading/re-parsing ~35 MB.
+_companias_cache = TtlCache(ttl_seconds=21600.0, max_entries=1)
+# Guards the cache-miss path so concurrent callers don't each independently
+# download+parse the full export (a ~30-40s, ~35 MB operation).
+_fetch_lock = asyncio.Lock()
+
+# Lazily-built RUC -> row index, invalidated whenever the cached row list is
+# replaced (compared by identity, not equality, so a cache refresh always
+# rebuilds it). Only get_compania_by_ruc needs this; search_companias doesn't,
+# so it isn't computed on every cache refresh regardless of which tool is used.
+_ruc_index_state: tuple[list[tuple[str, ...]], dict[str, tuple[str, ...]]] | None = None
+_expediente_index_state: (
+    tuple[list[tuple[str, ...]], dict[str, tuple[str, ...]]] | None
+) = None
+
+
+def _strip(text: str) -> str:
+    nfkd = normalize("NFKD", text or "")
+    return "".join(c for c in nfkd if category(c) != "Mn").lower()
+
+
+def _normalize_header(header: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", _strip(header)).strip("_")
+
+
+def _col_index(ref: str) -> int:
+    """Convert a cell reference like 'AC12' to a 0-based column index."""
+    letters = "".join(c for c in ref if c.isalpha())
+    idx = 0
+    for c in letters:
+        idx = idx * 26 + (ord(c.upper()) - ord("A") + 1)
+    return idx - 1
+
+
+def _first_worksheet_path(z: zipfile.ZipFile) -> str:
+    """Resolve the first sheet listed in xl/workbook.xml via its relationship.
+
+    Not assumed to be "xl/worksheets/sheet1.xml": that's true for the current
+    export, but only because of how its generator happens to lay out the zip,
+    not because OOXML guarantees it. Reading the actual sheet ->
+    relationship -> target mapping means an export that gains a second or
+    reordered sheet still resolves to the right one instead of silently
+    parsing the wrong worksheet.
+    """
+    try:
+        with z.open("xl/workbook.xml") as f:
+            wb_root = ET.parse(f).getroot()
+        sheet_elem = wb_root.find(f"{_NS}sheets/{_NS}sheet")
+        if sheet_elem is None:
+            raise ValueError("xl/workbook.xml no declara ninguna hoja")
+        r_id = sheet_elem.get(f"{_R_NS}id")
+
+        with z.open("xl/_rels/workbook.xml.rels") as f:
+            rels_root = ET.parse(f).getroot()
+        for rel in rels_root.findall(f"{_REL_NS}Relationship"):
+            if rel.get("Id") == r_id:
+                target = rel.get("Target") or ""
+                # OPC relationship targets are either package-root-relative
+                # ("/xl/worksheets/sheet1.xml", seen from openpyxl) or
+                # relative to the referencing part's directory
+                # ("worksheets/sheet1.xml", relative to "xl/" since this
+                # relates from xl/workbook.xml — seen in the real Supercías
+                # export).
+                if target.startswith("/"):
+                    return target.lstrip("/")
+                return f"xl/{target}"
+        raise ValueError(f"No se encontró la relación '{r_id}' de la primera hoja")
+    except KeyError as exc:
+        raise ValueError(
+            "El export de Supercías no tiene la estructura OOXML esperada "
+            "(falta xl/workbook.xml o xl/_rels/workbook.xml.rels)"
+        ) from exc
+
+
+def _read_shared_strings(z: zipfile.ZipFile) -> list[str]:
+    # Present when strings are stored by index (the real Supercías export);
+    # absent for writers that use inline strings instead (e.g. some openpyxl
+    # configurations, including this project's own test fixtures).
+    if "xl/sharedStrings.xml" not in z.namelist():
+        return []
+    shared: list[str] = []
+    with z.open("xl/sharedStrings.xml") as f:
+        for _, elem in ET.iterparse(f):
+            if elem.tag == _NS + "si":
+                texts = elem.findall(f".//{_NS}t")
+                shared.append("".join(t.text or "" for t in texts))
+                elem.clear()
+    return shared
+
+
+def _row_cells(elem: ET.Element, shared: list[str]) -> dict[int, str]:
+    cells: dict[int, str] = {}
+    for c in elem.findall(_NS + "c"):
+        ref = c.get("r")
+        if not ref:
+            continue
+        cell_type = c.get("t")
+        if cell_type == "inlineStr":
+            inline = c.find(_NS + "is")
+            if inline is None:
+                continue
+            texts = inline.findall(f".//{_NS}t")
+            cells[_col_index(ref)] = "".join(t.text or "" for t in texts)
+            continue
+        v = c.find(_NS + "v")
+        if v is None or v.text is None:
+            continue
+        val = v.text
+        if cell_type == "s":
+            val = shared[int(val)]
+        cells[_col_index(ref)] = val
+    return cells
+
+
+def _parse_xlsx(
+    raw: bytes, header_markers: tuple[str, ...] = ("ruc", "nombre")
+) -> tuple[tuple[str, ...], list[tuple[str, ...]]]:
+    """Parse a Supercías Excel export into (fields, rows).
+
+    `header_markers` are the normalized column names used to detect which
+    scanned row is the real header — every Supercías export has a few
+    title/metadata rows before it. Different reports use different id
+    columns (the company directory has "RUC", the external-auditors report
+    has "IDENTIFICACION" instead), so this isn't hardcoded to one report.
+    """
+    with zipfile.ZipFile(io.BytesIO(raw)) as z:
+        shared = _read_shared_strings(z)
+        sheet_path = _first_worksheet_path(z)
+        fields: tuple[str, ...] | None = None
+        rows: list[tuple[str, ...]] = []
+        scanned = 0
+        max_seen_col = -1
+        header_label = "/".join(m.upper() for m in header_markers)
+        with z.open(sheet_path) as f:
+            for _, elem in ET.iterparse(f, events=("end",)):
+                if elem.tag != _NS + "row":
+                    continue
+                cells = _row_cells(elem, shared)
+                elem.clear()
+                row_max = max(cells, default=-1)
+                max_seen_col = max(max_seen_col, row_max)
+                if fields is None:
+                    scanned += 1
+                    if scanned > _HEADER_SCAN_LIMIT:
+                        raise ValueError(
+                            f"No se encontró la fila de encabezado ({header_label}) "
+                            "en el reporte de Supercías"
+                        )
+                    candidate = tuple(
+                        _normalize_header(cells.get(i, "")) for i in range(row_max + 1)
+                    )
+                    if all(marker in candidate for marker in header_markers):
+                        fields = candidate
+                    continue
+                width = len(fields)
+                rows.append(tuple(cells.get(i, "") for i in range(width)))
+        if fields is None:
+            raise ValueError(
+                f"No se encontró la fila de encabezado ({header_label}) en el "
+                "reporte de Supercías"
+            )
+        if max_seen_col >= len(fields):
+            # A data row has a cell past the last column the header row
+            # produced — the header itself must be missing trailing
+            # columns (most likely a blank header cell dropped entirely
+            # from the row's XML rather than an empty string). Fail loudly
+            # instead of silently truncating every row to fewer columns
+            # than the file actually has.
+            raise ValueError(
+                f"El reporte de Supercías tiene datos en la columna "
+                f"{max_seen_col + 1}, más allá de las {len(fields)} columnas "
+                "detectadas en el encabezado; el encabezado parece estar "
+                "incompleto"
+            )
+        return fields, rows
+
+
+async def _download_once(url: str, verify: bool = True) -> bytes:
+    async with (
+        httpx.AsyncClient(
+            headers={"User-Agent": USER_AGENT},
+            follow_redirects=True,
+            timeout=_DOWNLOAD_TIMEOUT,
+            verify=verify,
+        ) as session,
+        session.stream("GET", url) as resp,
+    ):
+        resp.raise_for_status()
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in resp.aiter_bytes(chunk_size=256 * 1024):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > _MAX_DOWNLOAD_BYTES:
+                raise ValueError(
+                    f"El export de Supercías superó el límite de "
+                    f"{_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB; se abortó la descarga"
+                )
+    return b"".join(chunks)
+
+
+async def _download_full(url: str) -> bytes:
+    try:
+        return await _download_once(url)
+    except httpx.ConnectError as exc:
+        if not should_retry_insecure(exc, url):
+            raise
+        logger.warning(
+            "Fallo la verificación TLS para %s (¿certificado de Supercías con "
+            "problemas?); reintentando sin verificación",
+            url,
+        )
+        return await _download_once(url, verify=False)
+
+
+async def _fetch_companias() -> tuple[
+    tuple[str, ...], list[tuple[str, ...]], list[str], list[str], list[str]
+]:
+    """Return (fields, rows, normalized_names, normalized_provincias,
+    normalized_situaciones), from cache or fresh."""
+    cached = _companias_cache.get("companias")
+    if cached is not None:
+        return cached
+
+    async with _fetch_lock:
+        # Another coroutine may have populated the cache while this one was
+        # waiting for the lock; re-check before downloading again.
+        cached = _companias_cache.get("companias")
+        if cached is not None:
+            return cached
+
+        logger.info("Descargando y parseando el directorio de Supercías (~35 MB)")
+        try:
+            raw = await _download_full(_EXCEL_URL)
+            # _parse_xlsx is CPU-bound (streaming XML parse over ~35 MB) and
+            # takes seconds; running it inline would block the event loop for
+            # every other concurrent request on this server for that whole
+            # window, not just this one.
+            fields, rows = await asyncio.to_thread(_parse_xlsx, raw)
+        except Exception:
+            logger.exception("Fallo al descargar/parsear el directorio de Supercías")
+            raise
+
+        nombre_pos = fields.index("nombre")
+        provincia_pos = fields.index("provincia")
+        situacion_pos = fields.index("situacion_legal")
+        normalized_names = [_strip(row[nombre_pos]) for row in rows]
+        normalized_provincias = [_strip(row[provincia_pos]) for row in rows]
+        normalized_situaciones = [_strip(row[situacion_pos]) for row in rows]
+
+        bundle = (fields, rows, normalized_names, normalized_provincias, normalized_situaciones)
+        _companias_cache.set("companias", bundle)
+        logger.info("Directorio de Supercías cargado: %d compañías", len(rows))
+        return bundle
+
+
+def _ruc_index_for(
+    fields: tuple[str, ...], rows: list[tuple[str, ...]]
+) -> dict[str, tuple[str, ...]]:
+    """Build (and cache, by identity of `rows`) the RUC -> row lookup.
+
+    Built lazily instead of alongside the main table in `_fetch_companias`
+    because only get_compania_by_ruc needs it; search_companias doesn't, so
+    a cache window with only search calls never pays for it.
+    """
+    global _ruc_index_state
+    if _ruc_index_state is not None and _ruc_index_state[0] is rows:
+        return _ruc_index_state[1]
+
+    ruc_pos = fields.index("ruc")
+    index: dict[str, tuple[str, ...]] = {}
+    duplicates = 0
+    for row in rows:
+        ruc = row[ruc_pos]
+        if not ruc:
+            continue
+        if ruc in index:
+            duplicates += 1
+        index[ruc] = row
+    if duplicates:
+        logger.warning(
+            "Directorio de Supercías: %d RUC(s) duplicados en el export; "
+            "se conserva la última fila vista de cada uno",
+            duplicates,
+        )
+    _ruc_index_state = (rows, index)
+    return index
+
+
+def _expediente_index_for(
+    fields: tuple[str, ...], rows: list[tuple[str, ...]]
+) -> dict[str, tuple[str, ...]]:
+    """Build (and cache, by identity of `rows`) the expediente -> row lookup.
+
+    Same lazy-by-identity pattern as `_ruc_index_for`; kept as a separate
+    dict rather than folded into it since the two id spaces don't overlap
+    (expediente is a small integer string, RUC is 13 digits) but callers
+    look up by one or the other, not both.
+    """
+    global _expediente_index_state
+    if _expediente_index_state is not None and _expediente_index_state[0] is rows:
+        return _expediente_index_state[1]
+
+    expediente_pos = fields.index("expediente")
+    index: dict[str, tuple[str, ...]] = {}
+    for row in rows:
+        expediente = row[expediente_pos]
+        if expediente:
+            index[expediente] = row
+    _expediente_index_state = (rows, index)
+    return index
+
+
+def _row_to_dict(fields: tuple[str, ...], row: tuple[str, ...]) -> dict[str, str]:
+    return dict(zip(fields, row, strict=True))
+
+
+async def search_companias(
+    query: str = "",
+    provincia: str = "",
+    situacion_legal: str = "",
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """
+    Search the Supercías company directory client-side.
+
+    Args:
+        query: Free text matched (accent-insensitive) against company name or RUC.
+        provincia: Optional substring filter on province (accent-insensitive).
+        situacion_legal: Optional substring filter on legal status.
+        limit: Max results returned.
+        offset: Pagination offset over the matched set.
+    """
+    fields, rows, normalized_names, normalized_provincias, normalized_situaciones = (
+        await _fetch_companias()
+    )
+    ruc_pos = fields.index("ruc")
+
+    q = _strip(query)
+    prov = _strip(provincia)
+    situ = _strip(situacion_legal)
+
+    matched: list[int] = []
+    for i, row in enumerate(rows):
+        if q and q not in normalized_names[i] and q not in row[ruc_pos]:
+            continue
+        if prov and prov not in normalized_provincias[i]:
+            continue
+        if situ and situ not in normalized_situaciones[i]:
+            continue
+        matched.append(i)
+
+    page = matched[offset : offset + limit]
+    return {
+        "total": len(matched),
+        "offset": offset,
+        "source": "Superintendencia de Compañías, Valores y Seguros — Directorio de Companias",
+        "url_fuente": _EXCEL_URL,
+        "companias": [_row_to_dict(fields, rows[i]) for i in page],
+    }
+
+
+async def get_compania_by_ruc(ruc: str) -> dict[str, str] | None:
+    """Look up a single company by exact RUC match."""
+    fields, rows, *_ = await _fetch_companias()
+    ruc_index = _ruc_index_for(fields, rows)
+    row = ruc_index.get((ruc or "").strip())
+    if row is None:
+        return None
+    return _row_to_dict(fields, row)
+
+
+async def get_compania_by_expediente(expediente: str) -> dict[str, str] | None:
+    """Look up a single company by exact expediente match.
+
+    search_companias's free-text query only matches name/RUC, not
+    expediente, so it cannot be used as a substitute for this -- a caller
+    that tried `search_companias(query=str(expediente))` would silently
+    get no match for almost every real expediente.
+    """
+    fields, rows, *_ = await _fetch_companias()
+    expediente_index = _expediente_index_for(fields, rows)
+    row = expediente_index.get((expediente or "").strip())
+    if row is None:
+        return None
+    return _row_to_dict(fields, row)
+
+
+# Separate, much smaller export (~190 KB / 1,447 rows vs. ~35 MB / 226k) --
+# the registry of firms/individuals authorized to act as external auditors
+# in Ecuador. Same host, same title-rows-before-header quirk, but its id
+# column is "IDENTIFICACION" rather than "RUC", so it needs its own header
+# markers when calling the shared _parse_xlsx.
+_AUDITORES_EXCEL_URL = (
+    "https://mercadodevalores.supercias.gob.ec/reportes/excel/auditores_externos.xlsx"
+)
+_auditores_cache = TtlCache(ttl_seconds=21600.0, max_entries=1)
+_auditores_fetch_lock = asyncio.Lock()
+
+_identificacion_index_state: (
+    tuple[list[tuple[str, ...]], dict[str, tuple[str, ...]]] | None
+) = None
+
+
+async def _fetch_auditores() -> tuple[
+    tuple[str, ...], list[tuple[str, ...]], list[str], list[str]
+]:
+    """Return (fields, rows, normalized_names, normalized_provincias), from cache or fresh."""
+    cached = _auditores_cache.get("auditores")
+    if cached is not None:
+        return cached
+
+    async with _auditores_fetch_lock:
+        cached = _auditores_cache.get("auditores")
+        if cached is not None:
+            return cached
+
+        logger.info("Descargando y parseando el listado de auditores externos de Supercías")
+        try:
+            raw = await _download_full(_AUDITORES_EXCEL_URL)
+            fields, rows = _parse_xlsx(raw, header_markers=("identificacion", "nombre"))
+        except Exception:
+            logger.exception("Fallo al descargar/parsear el listado de auditores externos")
+            raise
+
+        nombre_pos = fields.index("nombre")
+        provincia_pos = fields.index("provincia")
+        normalized_names = [_strip(row[nombre_pos]) for row in rows]
+        normalized_provincias = [_strip(row[provincia_pos]) for row in rows]
+
+        bundle = (fields, rows, normalized_names, normalized_provincias)
+        _auditores_cache.set("auditores", bundle)
+        logger.info("Listado de auditores externos cargado: %d registros", len(rows))
+        return bundle
+
+
+def _identificacion_index_for(
+    fields: tuple[str, ...], rows: list[tuple[str, ...]]
+) -> dict[str, tuple[str, ...]]:
+    """Build (and cache, by identity of `rows`) the identificación -> row lookup."""
+    global _identificacion_index_state
+    if _identificacion_index_state is not None and _identificacion_index_state[0] is rows:
+        return _identificacion_index_state[1]
+
+    id_pos = fields.index("identificacion")
+    index: dict[str, tuple[str, ...]] = {}
+    for row in rows:
+        identificacion = row[id_pos]
+        if identificacion:
+            index[identificacion] = row
+    _identificacion_index_state = (rows, index)
+    return index
+
+
+async def search_auditores(
+    query: str = "",
+    provincia: str = "",
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """
+    Search the Supercías external-auditors registry client-side.
+
+    Args:
+        query: Free text matched (accent-insensitive) against auditor name
+            or identificación (RUC/cédula).
+        provincia: Optional substring filter on province (accent-insensitive).
+        limit: Max results returned.
+        offset: Pagination offset over the matched set.
+    """
+    fields, rows, normalized_names, normalized_provincias = await _fetch_auditores()
+    id_pos = fields.index("identificacion")
+
+    q = _strip(query)
+    prov = _strip(provincia)
+
+    matched: list[int] = []
+    for i, row in enumerate(rows):
+        if q and q not in normalized_names[i] and q not in row[id_pos]:
+            continue
+        if prov and prov not in normalized_provincias[i]:
+            continue
+        matched.append(i)
+
+    page = matched[offset : offset + limit]
+    return {
+        "total": len(matched),
+        "offset": offset,
+        "source": (
+            "Superintendencia de Compañías, Valores y Seguros — "
+            "Listado de Auditores Externos"
+        ),
+        "url_fuente": _AUDITORES_EXCEL_URL,
+        "auditores": [_row_to_dict(fields, rows[i]) for i in page],
+    }
+
+
+async def get_auditor_info(identificacion: str) -> dict[str, str] | None:
+    """Look up a single external auditor by exact identificación (RUC/cédula) match."""
+    fields, rows, *_ = await _fetch_auditores()
+    id_index = _identificacion_index_for(fields, rows)
+    row = id_index.get((identificacion or "").strip())
+    if row is None:
+        return None
+    return _row_to_dict(fields, row)

--- a/helpers/supercias_financials.py
+++ b/helpers/supercias_financials.py
@@ -1,0 +1,278 @@
+"""Query layer over the Supercías financial-ranking dataset (bi_ranking.csv).
+
+Distinct from helpers/supercias_client.py's company directory: this is the
+"Ranking" dataset (https://appscvsmovil.supercias.gob.ec/ranking/reporte.html),
+derived from real balance-sheet filings — revenue, assets, equity, profit,
+and ~38 financial ratios per company per fiscal year. The directory only has
+"capital suscrito"; this has actual financial performance.
+
+The source CSV (bi_ranking.csv) is ~356 MB / ~9M rows covering 2008-present,
+too large to hold in memory the way supercias_client.py holds the (also
+large, but 10x smaller) company directory. Instead this module only ever
+*queries* a local SQLite database that `scripts/build_supercias_financials_db.py`
+builds ahead of time, pruned to the last 5 fiscal years during that build.
+That script is meant to be run by the server operator before deploying, or
+on a periodic schedule (the underlying data refreshes far less often than
+the daily-updated company directory) — not lazily inside a request the way
+supercias_client.py's TtlCache does, because a from-scratch build downloads
+the full 356 MB file and takes minutes, not the ~30-40s that's tolerable
+for a single MCP tool call.
+
+Company names/RUCs are resolved from this same SQLite DB's own `companias`
+table (loaded from bi_compania.csv by the build script), not by calling into
+helpers.supercias_client's separately-cached directory. An earlier version
+did the latter and had a real bug for it: get_financials(expediente) needed
+a name/RUC lookup, that module's search only matched name/RUC text (not
+expediente), so the lookup silently failed almost every time. Duplicating
+three small columns (expediente, ruc, nombre) for ~226k rows is cheap next
+to the ~180 MB this DB already is, and removes that cross-module dependency
+entirely -- this module's queries never await anything from
+helpers.supercias_client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+DB_PATH = Path(__file__).resolve().parents[1] / "data" / "supercias_financials.sqlite3"
+# The dataset refreshes far less often than the daily company directory;
+# treat a build older than this as stale rather than silently serving it.
+_MAX_DB_AGE_SECONDS = 7 * 24 * 3600
+
+_RANKING_COLUMNS = (
+    "anio", "expediente", "posicion_general", "cia_imvalores",
+    "id_estado_financiero", "ingresos_ventas", "activos", "patrimonio",
+    "utilidad_an_imp", "impuesto_renta", "n_empleados", "ingresos_totales",
+    "utilidad_ejercicio", "utilidad_neta", "cod_segmento", "ciiu_n1",
+    "ciiu_n6", "liquidez_corriente", "prueba_acida", "end_activo",
+    "end_patrimonial", "end_activo_fijo", "end_corto_plazo",
+    "end_largo_plazo", "cobertura_interes", "apalancamiento",
+    "apalancamiento_financiero", "end_patrimonial_ct", "end_patrimonial_nct",
+    "apalancamiento_c_l_plazo", "rot_cartera", "rot_activo_fijo",
+    "rot_ventas", "per_med_cobranza", "per_med_pago", "impac_gasto_a_v",
+    "impac_carga_finan", "rent_neta_activo", "margen_bruto",
+    "margen_operacional", "rent_neta_ventas", "rent_ope_patrimonio",
+    "rent_ope_activo", "roe", "roa", "fortaleza_patrimonial",
+    "gastos_financieros", "gastos_admin_ventas", "depreciaciones",
+    "amortizaciones", "costos_ventas_prod", "deuda_total",
+    "deuda_total_c_plazo", "total_gastos",
+)
+
+# Qualified with the "r." alias used in search_ranking's JOIN query, so an
+# unqualified user-supplied order_by can't collide with a companias column.
+_ORDERABLE_COLUMNS = frozenset(_RANKING_COLUMNS)
+
+
+class FinancialsDbUnavailable(Exception):
+    """Raised when the SQLite build is missing or older than _MAX_DB_AGE_SECONDS."""
+
+
+def _check_db_fresh(path: Path | None = None) -> None:
+    # Read the module attribute at call time, not as a bound default -- a
+    # default evaluated at def-time would freeze the original DB_PATH value,
+    # which breaks tests (and anything else) that monkeypatch DB_PATH.
+    if path is None:
+        path = DB_PATH
+    if not path.exists():
+        raise FinancialsDbUnavailable(
+            "La base de datos financiera de Supercías no existe todavía. "
+            "Corre `python scripts/build_supercias_financials_db.py` en el "
+            "servidor y vuelve a intentar (tarda varios minutos la primera vez)."
+        )
+    age = time.time() - path.stat().st_mtime
+    if age > _MAX_DB_AGE_SECONDS:
+        days = int(age // 86400)
+        raise FinancialsDbUnavailable(
+            f"La base de datos financiera de Supercías tiene {days} días de "
+            "antigüedad y se considera desactualizada. Corre "
+            "`python scripts/build_supercias_financials_db.py` para refrescarla."
+        )
+
+
+def _connect(path: Path | None = None) -> sqlite3.Connection:
+    if path is None:
+        path = DB_PATH
+    _check_db_fresh(path)
+    conn = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _resolve_expediente(value: str) -> int | None:
+    """expediente is a small integer; a 13-digit numeric string is a RUC instead."""
+    value = (value or "").strip()
+    if not value:
+        return None
+    if value.isdigit() and len(value) != 13:
+        return int(value)
+    return None
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return dict(row)
+
+
+def _lookup_compania(
+    conn: sqlite3.Connection, expediente: int
+) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT expediente, ruc, nombre FROM companias WHERE expediente = ?",
+        (expediente,),
+    ).fetchone()
+    return _row_to_dict(row) if row else None
+
+
+def _resolve_expediente_by_ruc(conn: sqlite3.Connection, ruc: str) -> int | None:
+    row = conn.execute(
+        "SELECT expediente FROM companias WHERE ruc = ?", (ruc,)
+    ).fetchone()
+    return row["expediente"] if row else None
+
+
+def _query_get_financials(
+    expediente_or_ruc: str, anio: int | None
+) -> dict[str, Any]:
+    conn = _connect()
+    try:
+        expediente = _resolve_expediente(expediente_or_ruc)
+        if expediente is None:
+            ruc = (expediente_or_ruc or "").strip()
+            expediente = _resolve_expediente_by_ruc(conn, ruc)
+            if expediente is None:
+                return {
+                    "error": "not_found",
+                    "expediente_or_ruc": expediente_or_ruc,
+                    "years": [],
+                }
+
+        # Best-effort name/RUC lookup for display; not fatal if it's missing
+        # since a company can appear in `ranking` (from bi_ranking.csv) even
+        # if it's absent from `companias` (from bi_compania.csv) -- the two
+        # source files aren't guaranteed to be in perfect lockstep.
+        compania = _lookup_compania(conn, expediente)
+
+        if anio is not None:
+            cur = conn.execute(
+                "SELECT * FROM ranking WHERE expediente = ? AND anio = ? "
+                "ORDER BY anio DESC",
+                (expediente, anio),
+            )
+        else:
+            cur = conn.execute(
+                "SELECT * FROM ranking WHERE expediente = ? ORDER BY anio DESC",
+                (expediente,),
+            )
+        years = [_row_to_dict(r) for r in cur.fetchall()]
+
+        return {
+            "expediente": expediente,
+            "nombre": compania.get("nombre") if compania else None,
+            "ruc": compania.get("ruc") if compania else None,
+            "years": years,
+        }
+    finally:
+        conn.close()
+
+
+def _query_search_ranking(
+    anio: int | None,
+    ciiu_n1: str,
+    order_by: str,
+    limit: int,
+    offset: int,
+) -> tuple[int, list[dict[str, Any]]]:
+    conn = _connect()
+    try:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if anio is not None:
+            clauses.append("r.anio = ?")
+            params.append(anio)
+        if ciiu_n1:
+            clauses.append("r.ciiu_n1 = ?")
+            params.append(ciiu_n1.strip().upper())
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+
+        total = conn.execute(
+            f"SELECT COUNT(*) FROM ranking r {where}", params
+        ).fetchone()[0]
+
+        sort_col = order_by if order_by in _ORDERABLE_COLUMNS else "posicion_general"
+        # LEFT JOIN, not INNER: a ranking row missing from companias should
+        # still come back (with ruc/nombre as None) rather than silently
+        # vanish from results.
+        cur = conn.execute(
+            f"""
+            SELECT r.*, c.ruc AS ruc, c.nombre AS nombre
+            FROM ranking r
+            LEFT JOIN companias c ON c.expediente = r.expediente
+            {where}
+            ORDER BY r.{sort_col} ASC
+            LIMIT ? OFFSET ?
+            """,
+            (*params, limit, offset),
+        )
+        return total, [_row_to_dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def _query_sector_benchmark(anio: int, ciiu_n1: str) -> dict[str, Any] | None:
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            "SELECT * FROM indicadores_sector WHERE anio = ? AND ciiu_n1 = ?",
+            (anio, ciiu_n1.strip().upper()),
+        )
+        row = cur.fetchone()
+        return _row_to_dict(row) if row else None
+    finally:
+        conn.close()
+
+
+async def get_financials(
+    expediente_or_ruc: str, anio: int | None = None
+) -> dict[str, Any]:
+    """
+    Financial history for a company, most recent fiscal year first.
+
+    Args:
+        expediente_or_ruc: Either the company's Supercías "expediente" number
+            or its 13-digit RUC (resolved to expediente via this DB's own
+            `companias` table).
+        anio: Optional single fiscal year filter.
+    """
+    return await asyncio.to_thread(_query_get_financials, expediente_or_ruc, anio)
+
+
+async def search_ranking(
+    anio: int | None = None,
+    ciiu_n1: str = "",
+    order_by: str = "posicion_general",
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """
+    Filter/rank companies within the cached fiscal years.
+
+    Args:
+        anio: Optional fiscal year filter.
+        ciiu_n1: Optional CIIU level-1 economic activity filter (single letter).
+        order_by: Column to sort by (any ranking column; defaults to the
+            dataset's own precomputed posicion_general).
+        limit: Max results.
+        offset: Pagination offset.
+    """
+    total, rows = await asyncio.to_thread(
+        _query_search_ranking, anio, ciiu_n1, order_by, limit, offset
+    )
+    return {"total": total, "offset": offset, "companias": rows}
+
+
+async def get_sector_benchmark(anio: int, ciiu_n1: str) -> dict[str, Any] | None:
+    """Sector-level average of the same ratios, for one fiscal year + CIIU level-1."""
+    return await asyncio.to_thread(_query_sector_benchmark, anio, ciiu_n1)

--- a/helpers/tls.py
+++ b/helpers/tls.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 _INSECURE_TLS_HOST_SUFFIXES = (
     "datosabiertos.gob.ec",
     "datosabiertos.presidencia.gob.ec",
+    "mercadodevalores.supercias.gob.ec",
 )
 
 
@@ -58,3 +59,40 @@ def is_cert_verification_error(exc: BaseException) -> bool:
 def should_retry_insecure(exc: BaseException, url: str) -> bool:
     """True when a cert failure on an allowlisted host may be retried insecurely."""
     return host_allows_insecure_tls(url) and is_cert_verification_error(exc)
+
+
+# Hosts that fail the TLS handshake outright under OpenSSL 3's default
+# SECLEVEL=2 (SSLV3_ALERT_HANDSHAKE_FAILURE) because they only offer legacy
+# cipher suites — a different failure mode than an expired/invalid cert
+# (should_retry_insecure, above). Verified against
+# appscvsmovil.supercias.gob.ec: default httpx/OpenSSL settings fail the
+# handshake before a certificate is ever presented; lowering the cipher
+# security level to 1 connects fine and still verifies the certificate
+# normally. Keep this list separate from _INSECURE_TLS_HOST_SUFFIXES — the
+# two are not interchangeable and must not be merged into one allowlist.
+_LEGACY_CIPHER_HOST_SUFFIXES = ("appscvsmovil.supercias.gob.ec",)
+
+
+def host_needs_legacy_ciphers(url: str) -> bool:
+    """Return True only for hosts known to require SECLEVEL=1 to negotiate TLS."""
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return False
+    return any(
+        host == suffix or host.endswith("." + suffix)
+        for suffix in _LEGACY_CIPHER_HOST_SUFFIXES
+    )
+
+
+def legacy_cipher_context() -> ssl.SSLContext:
+    """SSLContext accepting legacy cipher suites, for hosts with old TLS configs.
+
+    Unlike the insecure-retry fallback above, this does not skip certificate
+    verification — it only lowers OpenSSL's minimum cipher strength
+    requirement (SECLEVEL) so the handshake with an old server config
+    completes at all. Build fresh per use; ssl.SSLContext is not guaranteed
+    safe to share/reuse across concurrent connections.
+    """
+    ctx = ssl.create_default_context()
+    ctx.set_ciphers("DEFAULT@SECLEVEL=1")
+    return ctx

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from tools import register_tools
 setup_logging()
 
 SERVER_START_TIME = datetime.now(UTC)
-VERSION = "0.5.0"
+VERSION = "0.5.4"
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ecuador-mcp"
-version = "0.5.1"
+version = "0.5.4"
 description = "Model Context Protocol (MCP) server for Ecuador open government data: CKAN, gob.ec, SERCOP OCDS, SGR risk events, and DPA geography."
 authors = [{ name = "Ecuador MCP Contributors" }]
 readme = "README.md"

--- a/resources/catalog.py
+++ b/resources/catalog.py
@@ -69,6 +69,26 @@ def register_catalog_resources(mcp: FastMCP) -> None:
                     "nombre": "DPA provincias, cantones y parroquias (referencia offline INEC)",
                     "tools": ["lookup_ubicacion"],
                 },
+                {
+                    "id": "supercias",
+                    "nombre": (
+                        "Superintendencia de Compañías (directorio de compañías, "
+                        "auditores externos)"
+                    ),
+                    "base": "https://mercadodevalores.supercias.gob.ec/reportes/",
+                    "tools": [
+                        "search_companias",
+                        "get_compania_info",
+                        "search_auditores",
+                        "get_auditor_info",
+                    ],
+                },
+                {
+                    "id": "supercias-financials",
+                    "nombre": "Superintendencia de Compañías (ranking financiero, últimos años)",
+                    "base": "https://appscvsmovil.supercias.gob.ec/ranking/",
+                    "tools": ["search_ranking", "get_financials"],
+                },
             ]
         }
         return json.dumps(payload, ensure_ascii=False, indent=2)

--- a/scripts/build_supercias_financials_db.py
+++ b/scripts/build_supercias_financials_db.py
@@ -1,0 +1,306 @@
+"""Build/refresh data/supercias_financials.sqlite3 from the Supercías ranking export.
+
+Downloads bi_ranking.csv (~356 MB, ~9M rows, 2008-present) plus the small
+lookup tables (bi_compania.csv, bi_segmento.csv, bi_ciiu.csv,
+indicadores_sector.csv) from
+https://appscvsmovil.supercias.gob.ec/ranking/reporte.html, loads them into a
+local SQLite database, then prunes `ranking`/`indicadores_sector` down to the
+last 5 fiscal years present in the data (not a hardcoded year, so this
+self-adjusts every year without a code change).
+
+Not run automatically by the MCP server: this takes several minutes (the
+356 MB download dominates), too slow for a single request/response cycle.
+Run it manually before deploying, or on a periodic schedule (the underlying
+filings change far less often than the daily company directory) --
+helpers/supercias_financials.py refuses to serve data older than 7 days.
+
+bi_compania.csv (expediente, ruc, nombre, tipo, pro_codigo, provincia) IS
+downloaded, as the `companias` table -- an earlier version of this script
+skipped it on the theory that helpers/supercias_client.py's directory cache
+already has the same fields, joined on `expediente`. That created a real
+coupling bug: get_financials()/search_ranking() need a live, separately
+warmed, separately-TTL'd cache from a different module just to show a
+company's name next to its financials. Duplicating three small columns for
+~226k rows is cheap (a few MB) next to the ~180 MB this DB already is, and
+makes this module fully self-contained.
+
+Usage:
+    uv run python scripts/build_supercias_financials_db.py
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from helpers.tls import legacy_cipher_context
+from helpers.user_agent import USER_AGENT
+
+ROOT = Path(__file__).resolve().parents[1]
+DB_PATH = ROOT / "data" / "supercias_financials.sqlite3"
+_RESOURCES_BASE = "https://appscvsmovil.supercias.gob.ec/ranking/recursos/"
+_TIMEOUT = 300.0
+_YEARS_TO_KEEP = 5
+_BATCH_SIZE = 5000
+
+_RANKING_INT_COLUMNS = {
+    "anio", "expediente", "posicion_general", "cia_imvalores",
+    "id_estado_financiero", "n_empleados", "cod_segmento",
+}
+_RANKING_TEXT_COLUMNS = {"ciiu_n1", "ciiu_n6"}
+
+_SECTOR_INT_COLUMNS = {"anio"}
+_SECTOR_TEXT_COLUMNS = {"ciiu_n1", "descripcion"}
+
+_COMPANIA_INT_COLUMNS = {"expediente"}
+_COMPANIA_TEXT_COLUMNS = {"ruc", "nombre", "tipo", "pro_codigo", "provincia"}
+
+
+def _client() -> httpx.Client:
+    return httpx.Client(
+        headers={"User-Agent": USER_AGENT},
+        verify=legacy_cipher_context(),
+        timeout=_TIMEOUT,
+        follow_redirects=True,
+    )
+
+
+def _download_to(client: httpx.Client, name: str, dest: Path) -> None:
+    url = _RESOURCES_BASE + name
+    print(f"Descargando {name}...", flush=True)
+    t0 = time.time()
+    total = 0
+    with client.stream("GET", url) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_bytes(chunk_size=1024 * 1024):
+                f.write(chunk)
+                total += len(chunk)
+                if total % (20 * 1024 * 1024) < len(chunk):
+                    print(f"  {total / (1024 * 1024):.0f} MB...", flush=True)
+    print(f"  {name}: {total / (1024 * 1024):.1f} MB en {time.time() - t0:.0f}s", flush=True)
+
+
+def _column_type(name: str, int_cols: set[str], text_cols: set[str]) -> str:
+    if name in int_cols:
+        return "INTEGER"
+    if name in text_cols:
+        return "TEXT"
+    return "REAL"
+
+
+def _convert(value: str, sql_type: str) -> object:
+    value = value.strip()
+    if not value:
+        return None
+    if sql_type == "TEXT":
+        return value
+    try:
+        return int(value) if sql_type == "INTEGER" else float(value)
+    except ValueError:
+        return None
+
+
+def _load_csv_table(
+    conn: sqlite3.Connection,
+    csv_path: Path,
+    table: str,
+    int_cols: set[str],
+    text_cols: set[str],
+) -> list[str]:
+    with open(csv_path, encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f)
+        header = [h.strip() for h in next(reader)]
+        types = [_column_type(h, int_cols, text_cols) for h in header]
+
+        cols_sql = ", ".join(f'"{h}" {t}' for h, t in zip(header, types, strict=True))
+        conn.execute(f'DROP TABLE IF EXISTS "{table}"')
+        conn.execute(f'CREATE TABLE "{table}" ({cols_sql})')
+        placeholders = ", ".join("?" for _ in header)
+        insert_sql = f'INSERT INTO "{table}" VALUES ({placeholders})'
+
+        batch: list[tuple] = []
+        n = 0
+        for row in reader:
+            if len(row) != len(header):
+                continue
+            batch.append(tuple(_convert(v, t) for v, t in zip(row, types, strict=True)))
+            if len(batch) >= _BATCH_SIZE:
+                conn.executemany(insert_sql, batch)
+                n += len(batch)
+                batch.clear()
+        if batch:
+            conn.executemany(insert_sql, batch)
+            n += len(batch)
+        conn.commit()
+        print(f"  {table}: {n} filas cargadas", flush=True)
+    return header
+
+
+def _verify_build(db_path: Path) -> None:
+    """Sanity-check a freshly built DB before it replaces the live one.
+
+    Cheap checks only (structural integrity, non-empty required tables,
+    expected columns) -- not a substitute for the row-level data-quality
+    reporting a future pass could add (see ROADMAP), but enough to catch
+    "the build silently produced garbage" before it overwrites a working DB.
+    """
+    conn = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True)
+    try:
+        ok = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if ok != "ok":
+            raise RuntimeError(f"PRAGMA integrity_check falló: {ok}")
+
+        for table, required_cols in (
+            ("ranking", {"anio", "expediente", "posicion_general"}),
+            ("companias", {"expediente", "ruc", "nombre"}),
+            ("segmentos", {"id_segmento", "segmento"}),
+            ("ciiu", {"ciiu", "descripcion"}),
+            ("indicadores_sector", {"anio", "ciiu_n1"}),
+        ):
+            cols = {row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')}
+            missing = required_cols - cols
+            if missing:
+                raise RuntimeError(f"Tabla '{table}' sin columnas {missing}")
+
+        companias_rows = conn.execute("SELECT COUNT(*) FROM companias").fetchone()[0]
+        if companias_rows == 0:
+            raise RuntimeError(
+                "La tabla 'companias' quedó vacía tras el build -- "
+                "probablemente bi_compania.csv vino roto/truncado esta vez"
+            )
+
+        ranking_rows = conn.execute("SELECT COUNT(*) FROM ranking").fetchone()[0]
+        if ranking_rows == 0:
+            raise RuntimeError(
+                "La tabla 'ranking' quedó vacía tras el build -- "
+                "probablemente el CSV fuente vino roto/truncado esta vez"
+            )
+        min_anio, max_anio = conn.execute(
+            "SELECT MIN(anio), MAX(anio) FROM ranking"
+        ).fetchone()
+        print(
+            f"  Verificación OK: {ranking_rows} filas en 'ranking' "
+            f"({companias_rows} en 'companias'), años {min_anio}-{max_anio}",
+            flush=True,
+        )
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = DB_PATH.parent / "tmp_supercias_financials"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    # Built alongside the live DB (not under tmp_dir, which gets removed
+    # below) so the final os.replace() is a same-filesystem rename, never a
+    # cross-filesystem copy that could itself fail partway through.
+    build_path = DB_PATH.parent / f"{DB_PATH.name}.building"
+
+    with _client() as client:
+        ranking_csv = tmp_dir / "bi_ranking.csv"
+        compania_csv = tmp_dir / "bi_compania.csv"
+        segmento_csv = tmp_dir / "bi_segmento.csv"
+        ciiu_csv = tmp_dir / "bi_ciiu.csv"
+        sector_csv = tmp_dir / "indicadores_sector.csv"
+        for name, dest in (
+            ("bi_ranking.csv", ranking_csv),
+            ("bi_compania.csv", compania_csv),
+            ("bi_segmento.csv", segmento_csv),
+            ("bi_ciiu.csv", ciiu_csv),
+            ("indicadores_sector.csv", sector_csv),
+        ):
+            _download_to(client, name, dest)
+
+    build_path.unlink(missing_ok=True)
+    conn = sqlite3.connect(build_path)
+    try:
+        print("Cargando bi_ranking.csv a SQLite (tabla 'ranking')...", flush=True)
+        _load_csv_table(conn, ranking_csv, "ranking", _RANKING_INT_COLUMNS, _RANKING_TEXT_COLUMNS)
+
+        max_anio = conn.execute("SELECT MAX(anio) FROM ranking").fetchone()[0]
+        if max_anio is not None:
+            cutoff = max_anio - (_YEARS_TO_KEEP - 1)
+            deleted = conn.execute(
+                "DELETE FROM ranking WHERE anio < ?", (cutoff,)
+            ).rowcount
+            conn.commit()
+            print(
+                f"  Recortado a anio >= {cutoff} "
+                f"(mantiene los últimos {_YEARS_TO_KEEP} años); {deleted} filas eliminadas",
+                flush=True,
+            )
+
+        print("Cargando bi_compania.csv (tabla 'companias')...", flush=True)
+        _load_csv_table(
+            conn, compania_csv, "companias", _COMPANIA_INT_COLUMNS, _COMPANIA_TEXT_COLUMNS
+        )
+
+        print("Cargando bi_segmento.csv (tabla 'segmentos')...", flush=True)
+        _load_csv_table(conn, segmento_csv, "segmentos", {"id_segmento"}, {"segmento"})
+
+        print("Cargando bi_ciiu.csv (tabla 'ciiu')...", flush=True)
+        _load_csv_table(conn, ciiu_csv, "ciiu", set(), {"ciiu", "descripcion"})
+
+        print("Cargando indicadores_sector.csv (tabla 'indicadores_sector')...", flush=True)
+        _load_csv_table(
+            conn, sector_csv, "indicadores_sector", _SECTOR_INT_COLUMNS, _SECTOR_TEXT_COLUMNS
+        )
+        if max_anio is not None:
+            conn.execute(
+                "DELETE FROM indicadores_sector WHERE anio < ?", (max_anio - (_YEARS_TO_KEEP - 1),)
+            )
+            conn.commit()
+
+        print("Creando índices...", flush=True)
+        conn.execute("CREATE INDEX idx_ranking_expediente ON ranking(expediente)")
+        conn.execute("CREATE INDEX idx_ranking_anio ON ranking(anio)")
+        conn.execute("CREATE INDEX idx_ranking_ciiu_anio ON ranking(ciiu_n1, anio)")
+        conn.execute(
+            "CREATE INDEX idx_sector_anio_ciiu ON indicadores_sector(anio, ciiu_n1)"
+        )
+        conn.execute("CREATE INDEX idx_companias_expediente ON companias(expediente)")
+        conn.execute("CREATE INDEX idx_companias_ruc ON companias(ruc)")
+        conn.commit()
+
+        print("VACUUM...", flush=True)
+        conn.execute("VACUUM")
+    except Exception:
+        conn.close()
+        build_path.unlink(missing_ok=True)
+        raise
+    else:
+        conn.close()
+
+    print("Verificando la base construida antes de reemplazar la anterior...", flush=True)
+    try:
+        _verify_build(build_path)
+    except Exception:
+        build_path.unlink(missing_ok=True)
+        raise
+
+    # Atomic on both POSIX and Windows, and same-filesystem (build_path
+    # lives next to DB_PATH) so this can't fail partway through the way a
+    # plain unlink()-then-write to DB_PATH directly could -- a reader
+    # opening DB_PATH mid-build would either see the old file or the new
+    # one, never a half-written one, and a failed build never touches the
+    # previously-working database at all.
+    os.replace(build_path, DB_PATH)
+
+    for f in (ranking_csv, compania_csv, segmento_csv, ciiu_csv, sector_csv):
+        f.unlink(missing_ok=True)
+    tmp_dir.rmdir()
+
+    print(f"Listo: {DB_PATH} ({DB_PATH.stat().st_size / (1024 * 1024):.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_supercias_financials_db.py
+++ b/tests/test_build_supercias_financials_db.py
@@ -1,0 +1,123 @@
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "build_supercias_financials_db.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "build_supercias_financials_db", _SCRIPT_PATH
+)
+build_script = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_script)
+
+
+def _valid_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ranking (anio INTEGER, expediente INTEGER, "
+        "posicion_general INTEGER)"
+    )
+    conn.execute("INSERT INTO ranking VALUES (2025, 1, 10)")
+    conn.execute(
+        "CREATE TABLE companias (expediente INTEGER, ruc TEXT, nombre TEXT)"
+    )
+    conn.execute("INSERT INTO companias VALUES (1, '1790013731001', 'ACME')")
+    conn.execute("CREATE TABLE segmentos (id_segmento INTEGER, segmento TEXT)")
+    conn.execute("CREATE TABLE ciiu (ciiu TEXT, descripcion TEXT)")
+    conn.execute(
+        "CREATE TABLE indicadores_sector (anio INTEGER, ciiu_n1 TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_verify_build_accepts_well_formed_db(tmp_path):
+    path = tmp_path / "ok.sqlite3"
+    _valid_db(path)
+    build_script._verify_build(path)  # must not raise
+
+
+def test_verify_build_rejects_empty_ranking_table(tmp_path):
+    path = tmp_path / "empty.sqlite3"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ranking (anio INTEGER, expediente INTEGER, "
+        "posicion_general INTEGER)"
+    )
+    conn.execute(
+        "CREATE TABLE companias (expediente INTEGER, ruc TEXT, nombre TEXT)"
+    )
+    conn.execute("INSERT INTO companias VALUES (1, '1790013731001', 'ACME')")
+    conn.execute("CREATE TABLE segmentos (id_segmento INTEGER, segmento TEXT)")
+    conn.execute("CREATE TABLE ciiu (ciiu TEXT, descripcion TEXT)")
+    conn.execute("CREATE TABLE indicadores_sector (anio INTEGER, ciiu_n1 TEXT)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="'ranking' quedó vacía"):
+        build_script._verify_build(path)
+
+
+def test_verify_build_rejects_empty_companias_table(tmp_path):
+    path = tmp_path / "empty_companias.sqlite3"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ranking (anio INTEGER, expediente INTEGER, "
+        "posicion_general INTEGER)"
+    )
+    conn.execute("INSERT INTO ranking VALUES (2025, 1, 10)")
+    conn.execute(
+        "CREATE TABLE companias (expediente INTEGER, ruc TEXT, nombre TEXT)"
+    )
+    conn.execute("CREATE TABLE segmentos (id_segmento INTEGER, segmento TEXT)")
+    conn.execute("CREATE TABLE ciiu (ciiu TEXT, descripcion TEXT)")
+    conn.execute("CREATE TABLE indicadores_sector (anio INTEGER, ciiu_n1 TEXT)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="'companias' quedó vacía"):
+        build_script._verify_build(path)
+
+
+def test_verify_build_rejects_missing_required_column(tmp_path):
+    path = tmp_path / "missing_col.sqlite3"
+    conn = sqlite3.connect(path)
+    # 'posicion_general' missing.
+    conn.execute("CREATE TABLE ranking (anio INTEGER, expediente INTEGER)")
+    conn.execute("INSERT INTO ranking VALUES (2025, 1)")
+    conn.execute(
+        "CREATE TABLE companias (expediente INTEGER, ruc TEXT, nombre TEXT)"
+    )
+    conn.execute("INSERT INTO companias VALUES (1, '1790013731001', 'ACME')")
+    conn.execute("CREATE TABLE segmentos (id_segmento INTEGER, segmento TEXT)")
+    conn.execute("CREATE TABLE ciiu (ciiu TEXT, descripcion TEXT)")
+    conn.execute("CREATE TABLE indicadores_sector (anio INTEGER, ciiu_n1 TEXT)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="posicion_general"):
+        build_script._verify_build(path)
+
+
+def test_verify_build_rejects_missing_table(tmp_path):
+    path = tmp_path / "missing_table.sqlite3"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ranking (anio INTEGER, expediente INTEGER, "
+        "posicion_general INTEGER)"
+    )
+    conn.execute("INSERT INTO ranking VALUES (2025, 1, 10)")
+    # 'companias', 'segmentos', 'ciiu', 'indicadores_sector' never created.
+    # PRAGMA table_info on a missing table returns no rows rather than
+    # erroring, so this surfaces as "missing all required columns", not a
+    # distinct "no such table" error -- either way, _verify_build must
+    # reject it. 'companias' is checked right after 'ranking', so that's
+    # the table named in the error here.
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(RuntimeError, match="companias"):
+        build_script._verify_build(path)

--- a/tests/test_supercias_client.py
+++ b/tests/test_supercias_client.py
@@ -1,0 +1,342 @@
+import io
+import ssl
+
+import httpx
+import openpyxl
+import pytest
+
+from helpers import supercias_client
+from helpers.cache import TtlCache
+
+_HEADER = (
+    "No. FILA", "EXPEDIENTE", "RUC", "NOMBRE", "SITUACIÓN LEGAL",
+    "FECHA_CONSTITUCION", "TIPO", "PAÍS", "REGIÓN", "PROVINCIA", "CANTÓN",
+    "CIUDAD", "CALLE", "NÚMERO", "INTERSECCIÓN", "BARRIO", "TELÉFONO",
+    "REPRESENTANTE", "CARGO", "CAPITAL SUSCRITO", "CIIU NIVEL 1",
+    "CIIU NIVEL 6", "ÚLTIMO BALANCE", "PRESENTÓ BALANCE INICIAL",
+    "FECHA PRESENTACIÓN BALANCE INICIAL",
+)
+
+_ROW_1 = (
+    1, "1", "1790013731001", "ACEITES TROPICALES SOCIEDAD ANONIMA ATSA",
+    "ACTIVA", "20/07/1951", "ANÓNIMA", "ECUADOR", "SIERRA", "PICHINCHA",
+    "QUITO", "QUITO", "VIA QUININDE KM 37", "SN", "SN", "", "022762426",
+    "ACOSTA LLERENA JUAN CARLOS", "GERENTE GENERAL", "48.200,00", "A",
+    "A0126.01", "2025", "NO APLICA", "NO APLICA",
+)
+_ROW_2 = (
+    2, "2", "1790004724001", "ACERIA DEL ECUADOR CA ADELCA.", "ACTIVA",
+    "17/12/1963", "ANÓNIMA", "ECUADOR", "SIERRA", "GUAYAS", "GUAYAQUIL",
+    "GUAYAQUIL", "PANAMERICANA NORTE", "S/N", "S/N", "", "023801321",
+    "DIRECACERO DIRECCION DE EMPRESAS DEL ACERO S.A.", "PRESIDENTE EJECUTIVO",
+    "125.500.000,00", "C", "C2410.25", "2025", "NO APLICA", "NO APLICA",
+)
+
+
+def _build_xlsx() -> bytes:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(("SUPERINTENDENCIA DE COMPAÑÍAS, VALORES Y SEGUROS",))
+    ws.append(("DIRECTORIO DE COMPAÑÍAS",))
+    ws.append(("No. DE FILAS: 2",))
+    ws.append(("FECHA DE ACTUALIZACION: 13/08/2026 00:53:11",))
+    ws.append(_HEADER)
+    ws.append(_ROW_1)
+    ws.append(_ROW_2)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _build_xlsx_with_duplicate_ruc() -> bytes:
+    dup_row = (
+        3, "3", "1790013731001", "ACEITES TROPICALES (EXPEDIENTE DUPLICADO)",
+        "ACTIVA", "20/07/1951", "ANÓNIMA", "ECUADOR", "SIERRA", "PICHINCHA",
+        "QUITO", "QUITO", "VIA QUININDE KM 37", "SN", "SN", "", "022762426",
+        "OTRO REPRESENTANTE", "GERENTE GENERAL", "48.200,00", "A",
+        "A0126.01", "2025", "NO APLICA", "NO APLICA",
+    )
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(("SUPERINTENDENCIA DE COMPAÑÍAS, VALORES Y SEGUROS",))
+    ws.append(("DIRECTORIO DE COMPAÑÍAS",))
+    ws.append(("No. DE FILAS: 3",))
+    ws.append(("FECHA DE ACTUALIZACION: 13/08/2026 00:53:11",))
+    ws.append(_HEADER)
+    ws.append(_ROW_1)
+    ws.append(_ROW_2)
+    ws.append(dup_row)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+_AUDITORES_HEADER = (
+    "RNAE", "IDENTIFICACIÓN", "NOMBRE", "NÚMERO DE RESOLUCIÓN",
+    "FECHA DE RESOLUCIÓN", "NACIONALIDAD", "PROVINCIA", "CANTÓN",
+    "DIRECCIÓN", "TELÉFONO", "CORREO ELECTRÓNICO",
+)
+
+_AUDITOR_ROW_1 = (
+    "1379", "1792904471001", "'ACG' ATTESTING & CONSULTING GROUP C.L.",
+    "35791", "25/10/2019", "ECUADOR", "PICHINCHA", "QUITO",
+    "AV. SOLANDA S24-37", "025129335", "info@acg-ec.com",
+)
+_AUDITOR_ROW_2 = (
+    "1424", "0993226475001", "'ADVANCED AUDIT ECUADOR' AAE CIA.LTDA.",
+    "11854", "15/06/2026", "ECUADOR", "GUAYAS", "GUAYAQUIL",
+    "AV. FRANCISCO DE ORELLANA", "042443199", "corellana@advanced.ec",
+)
+
+
+def _build_auditores_xlsx() -> bytes:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(("SUPERINTENDENCIA DE COMPAÑÍAS, VALORES Y SEGUROS",))
+    ws.append(("LISTADO DE AUDITORES EXTERNOS",))
+    ws.append(("No. DE FILAS: 2",))
+    ws.append(("FECHA DE ACTUALIZACION: 15/08/2026 00:05:14",))
+    ws.append(_AUDITORES_HEADER)
+    ws.append(_AUDITOR_ROW_1)
+    ws.append(_AUDITOR_ROW_2)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    supercias_client._companias_cache = TtlCache(ttl_seconds=60)
+    supercias_client._ruc_index_state = None
+    supercias_client._auditores_cache = TtlCache(ttl_seconds=60)
+    supercias_client._identificacion_index_state = None
+    yield
+
+
+def test_col_index():
+    assert supercias_client._col_index("A1") == 0
+    assert supercias_client._col_index("Z12") == 25
+    assert supercias_client._col_index("AA1") == 26
+
+
+def test_normalize_header():
+    assert supercias_client._normalize_header("SITUACIÓN LEGAL") == "situacion_legal"
+    assert supercias_client._normalize_header("No. FILA") == "no_fila"
+    assert supercias_client._normalize_header("CIIU NIVEL 1") == "ciiu_nivel_1"
+
+
+def test_parse_xlsx_skips_title_rows_and_detects_header():
+    fields, rows = supercias_client._parse_xlsx(_build_xlsx())
+
+    assert fields[2] == "ruc"
+    assert fields[3] == "nombre"
+    assert len(rows) == 2
+    assert rows[0][fields.index("ruc")] == "1790013731001"
+    assert rows[0][fields.index("nombre")] == "ACEITES TROPICALES SOCIEDAD ANONIMA ATSA"
+    assert rows[1][fields.index("provincia")] == "GUAYAS"
+
+
+def test_parse_xlsx_raises_without_header():
+    only_titles = io.BytesIO()
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    for _ in range(25):
+        ws.append(("no header here",))
+    wb.save(only_titles)
+
+    with pytest.raises(ValueError, match="encabezado"):
+        supercias_client._parse_xlsx(only_titles.getvalue())
+
+
+async def test_search_companias_by_name_and_ruc(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    by_name = await supercias_client.search_companias(query="aceria")
+    assert by_name["total"] == 1
+    assert by_name["companias"][0]["ruc"] == "1790004724001"
+
+    by_ruc = await supercias_client.search_companias(query="1790013731001")
+    assert by_ruc["total"] == 1
+    assert by_ruc["companias"][0]["nombre"].startswith("ACEITES TROPICALES")
+
+
+async def test_search_companias_filters_by_provincia_and_situacion(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    result = await supercias_client.search_companias(
+        provincia="guayas", situacion_legal="activa"
+    )
+    assert result["total"] == 1
+    assert result["companias"][0]["provincia"] == "GUAYAS"
+
+
+async def test_search_companias_uses_cache_across_calls(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    await supercias_client.search_companias(query="aceria")
+    # A second call must not trigger another network request (httpx_mock
+    # would fail the test on an unexpected/unmatched extra request).
+    await supercias_client.search_companias(query="aceites")
+
+
+async def test_get_compania_by_ruc_found_and_not_found(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    found = await supercias_client.get_compania_by_ruc("1790013731001")
+    assert found is not None
+    assert found["representante"] == "ACOSTA LLERENA JUAN CARLOS"
+
+    missing = await supercias_client.get_compania_by_ruc("0000000000000")
+    assert missing is None
+
+
+async def test_get_compania_by_expediente_found_and_not_found(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    found = await supercias_client.get_compania_by_expediente("1")
+    assert found is not None
+    assert found["nombre"] == "ACEITES TROPICALES SOCIEDAD ANONIMA ATSA"
+    assert found["ruc"] == "1790013731001"
+
+    missing = await supercias_client.get_compania_by_expediente("999999")
+    assert missing is None
+
+
+def test_parse_xlsx_raises_when_data_row_exceeds_header_width():
+    # Simulate a header row whose last cell is blank (dropped from the row's
+    # XML entirely) by writing the real header minus its last column, while
+    # a data row still has a value in that trailing column.
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(("SUPERINTENDENCIA DE COMPAÑÍAS, VALORES Y SEGUROS",))
+    ws.append(("DIRECTORIO DE COMPAÑÍAS",))
+    ws.append(("No. DE FILAS: 1",))
+    ws.append(("FECHA DE ACTUALIZACION: 13/08/2026 00:53:11",))
+    ws.append(_HEADER[:-1])
+    ws.append(_ROW_1)
+    buf = io.BytesIO()
+    wb.save(buf)
+
+    with pytest.raises(ValueError, match="incompleto"):
+        supercias_client._parse_xlsx(buf.getvalue())
+
+
+async def test_duplicate_ruc_keeps_last_row_and_logs_warning(httpx_mock, caplog):
+    httpx_mock.add_response(
+        url=supercias_client._EXCEL_URL, content=_build_xlsx_with_duplicate_ruc()
+    )
+
+    with caplog.at_level("WARNING"):
+        found = await supercias_client.get_compania_by_ruc("1790013731001")
+
+    assert found is not None
+    assert found["nombre"] == "ACEITES TROPICALES (EXPEDIENTE DUPLICADO)"
+    assert any("duplicado" in rec.message for rec in caplog.records)
+
+
+async def test_ruc_index_is_cached_across_lookups(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+
+    await supercias_client.get_compania_by_ruc("1790013731001")
+    state_after_first = supercias_client._ruc_index_state
+    assert state_after_first is not None
+
+    # A second lookup (and an unrelated search) must reuse the same index
+    # object rather than rebuilding it, since the underlying rows haven't
+    # changed.
+    await supercias_client.get_compania_by_ruc("1790004724001")
+    await supercias_client.search_companias(query="aceria")
+    assert supercias_client._ruc_index_state is state_after_first
+
+
+async def test_download_full_retries_insecurely_on_cert_failure(monkeypatch):
+    # CKAN_INSECURE_TLS defaults to off (post-cert-renewal); opt in explicitly
+    # to exercise the retry path itself.
+    monkeypatch.setenv("CKAN_INSECURE_TLS", "1")
+    calls: list[bool] = []
+
+    async def fake_download_once(url: str, verify: bool = True) -> bytes:
+        calls.append(verify)
+        if verify:
+            exc = httpx.ConnectError("cert failure")
+            exc.__context__ = ssl.SSLCertVerificationError("bad cert")
+            raise exc
+        return b"ok"
+
+    monkeypatch.setattr(supercias_client, "_download_once", fake_download_once)
+
+    result = await supercias_client._download_full(supercias_client._EXCEL_URL)
+
+    assert result == b"ok"
+    assert calls == [True, False]
+
+
+async def test_download_full_does_not_retry_non_cert_connect_errors(monkeypatch):
+    async def fake_download_once(url: str, verify: bool = True) -> bytes:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(supercias_client, "_download_once", fake_download_once)
+
+    with pytest.raises(httpx.ConnectError):
+        await supercias_client._download_full(supercias_client._EXCEL_URL)
+
+
+def test_parse_xlsx_uses_identificacion_header_marker_for_auditores():
+    fields, rows = supercias_client._parse_xlsx(
+        _build_auditores_xlsx(), header_markers=("identificacion", "nombre")
+    )
+
+    assert "identificacion" in fields
+    assert "nombre" in fields
+    assert len(rows) == 2
+    assert rows[0][fields.index("identificacion")] == "1792904471001"
+
+
+async def test_search_auditores_by_name_and_identificacion(httpx_mock):
+    httpx_mock.add_response(
+        url=supercias_client._AUDITORES_EXCEL_URL, content=_build_auditores_xlsx()
+    )
+
+    by_name = await supercias_client.search_auditores(query="advanced")
+    assert by_name["total"] == 1
+    assert by_name["auditores"][0]["identificacion"] == "0993226475001"
+
+    by_id = await supercias_client.search_auditores(query="1792904471001")
+    assert by_id["total"] == 1
+    assert "ACG" in by_id["auditores"][0]["nombre"]
+
+
+async def test_search_auditores_filters_by_provincia(httpx_mock):
+    httpx_mock.add_response(
+        url=supercias_client._AUDITORES_EXCEL_URL, content=_build_auditores_xlsx()
+    )
+
+    result = await supercias_client.search_auditores(provincia="guayas")
+    assert result["total"] == 1
+    assert result["auditores"][0]["provincia"] == "GUAYAS"
+
+
+async def test_get_auditor_info_found_and_not_found(httpx_mock):
+    httpx_mock.add_response(
+        url=supercias_client._AUDITORES_EXCEL_URL, content=_build_auditores_xlsx()
+    )
+
+    found = await supercias_client.get_auditor_info("1792904471001")
+    assert found is not None
+    assert found["rnae"] == "1379"
+
+    missing = await supercias_client.get_auditor_info("0000000000000")
+    assert missing is None
+
+
+async def test_auditores_and_companias_caches_are_independent(httpx_mock):
+    httpx_mock.add_response(url=supercias_client._EXCEL_URL, content=_build_xlsx())
+    httpx_mock.add_response(
+        url=supercias_client._AUDITORES_EXCEL_URL, content=_build_auditores_xlsx()
+    )
+
+    companias = await supercias_client.search_companias(query="aceria")
+    auditores = await supercias_client.search_auditores(query="advanced")
+
+    assert companias["total"] == 1
+    assert auditores["total"] == 1

--- a/tests/test_supercias_financials.py
+++ b/tests/test_supercias_financials.py
@@ -1,0 +1,158 @@
+import os
+import sqlite3
+import time
+
+import pytest
+
+from helpers import supercias_financials
+
+
+def _build_db(path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ranking (anio INTEGER, expediente INTEGER, "
+        "posicion_general INTEGER, ciiu_n1 TEXT, ciiu_n6 TEXT, "
+        "ingresos_ventas REAL, activos REAL, roe REAL)"
+    )
+    conn.executemany(
+        "INSERT INTO ranking VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (2025, 1, 10, "C", "C1010.01", 1000.0, 5000.0, 0.1),
+            (2024, 1, 15, "C", "C1010.01", 900.0, 4800.0, 0.09),
+            (2025, 2, 3, "G", "G4510.01", 3000.0, 9000.0, 0.2),
+            # expediente 3 has financials but no matching companias row --
+            # tests the LEFT JOIN / "predates directory coverage" case.
+            (2025, 3, 20, "C", "C1010.01", 500.0, 2000.0, 0.05),
+        ],
+    )
+    conn.execute(
+        "CREATE TABLE companias (expediente INTEGER, ruc TEXT, nombre TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO companias VALUES (?, ?, ?)",
+        [
+            (1, "1790013731001", "ACME"),
+            (2, "1790004724001", "OTRA S.A."),
+        ],
+    )
+    conn.execute("CREATE TABLE segmentos (id_segmento INTEGER, segmento TEXT)")
+    conn.execute("CREATE TABLE ciiu (ciiu TEXT, descripcion TEXT)")
+    conn.execute(
+        "CREATE TABLE indicadores_sector (anio INTEGER, ciiu_n1 TEXT, "
+        "descripcion TEXT, roe REAL)"
+    )
+    conn.execute(
+        "INSERT INTO indicadores_sector VALUES (2025, 'C', 'Manufactura', 0.08)"
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    path = tmp_path / "financials.sqlite3"
+    _build_db(path)
+    monkeypatch.setattr(supercias_financials, "DB_PATH", path)
+    return path
+
+
+def test_resolve_expediente_distinguishes_ruc_from_expediente():
+    assert supercias_financials._resolve_expediente("123") == 123
+    assert supercias_financials._resolve_expediente("1790013731001") is None
+    assert supercias_financials._resolve_expediente("") is None
+    assert supercias_financials._resolve_expediente("abc") is None
+
+
+def test_check_db_fresh_missing_file(tmp_path):
+    missing = tmp_path / "does_not_exist.sqlite3"
+    with pytest.raises(supercias_financials.FinancialsDbUnavailable, match="no existe"):
+        supercias_financials._check_db_fresh(missing)
+
+
+def test_check_db_fresh_stale_file(tmp_path):
+    path = tmp_path / "old.sqlite3"
+    path.write_bytes(b"")
+    old_time = time.time() - 8 * 24 * 3600
+    os.utime(path, (old_time, old_time))
+    with pytest.raises(
+        supercias_financials.FinancialsDbUnavailable, match="desactualizada"
+    ):
+        supercias_financials._check_db_fresh(path)
+
+
+async def test_get_financials_by_expediente(db_path):
+    result = await supercias_financials.get_financials("1")
+
+    assert result["expediente"] == 1
+    assert result["nombre"] == "ACME"
+    assert result["ruc"] == "1790013731001"
+    assert [y["anio"] for y in result["years"]] == [2025, 2024]
+
+
+async def test_get_financials_by_expediente_not_in_companias(db_path):
+    # Financial data must still come back even if the company is missing
+    # from the companias table (bi_ranking.csv and bi_compania.csv aren't
+    # guaranteed to be in perfect lockstep) -- only nombre/ruc is best-effort.
+    result = await supercias_financials.get_financials("3")
+
+    assert result["expediente"] == 3
+    assert result["nombre"] is None
+    assert result["ruc"] is None
+    assert [y["anio"] for y in result["years"]] == [2025]
+
+
+async def test_get_financials_by_ruc(db_path):
+    result = await supercias_financials.get_financials("1790004724001")
+
+    assert result["expediente"] == 2
+    assert result["nombre"] == "OTRA S.A."
+    assert len(result["years"]) == 1
+
+
+async def test_get_financials_ruc_not_found(db_path):
+    result = await supercias_financials.get_financials("0000000000000")
+
+    assert result["error"] == "not_found"
+    assert result["years"] == []
+
+
+async def test_search_ranking_filters_and_sorts(db_path):
+    result = await supercias_financials.search_ranking(anio=2025)
+    assert result["total"] == 3
+    # Sorted ascending by posicion_general by default.
+    assert [c["expediente"] for c in result["companias"]] == [2, 1, 3]
+
+
+async def test_search_ranking_includes_company_name_and_ruc(db_path):
+    result = await supercias_financials.search_ranking(anio=2025, ciiu_n1="c")
+    by_expediente = {c["expediente"]: c for c in result["companias"]}
+
+    assert by_expediente[1]["nombre"] == "ACME"
+    assert by_expediente[1]["ruc"] == "1790013731001"
+    # expediente 3 has no companias row -- LEFT JOIN must still return the
+    # ranking row, with nombre/ruc as None, not drop it.
+    assert by_expediente[3]["nombre"] is None
+    assert by_expediente[3]["ruc"] is None
+
+
+async def test_search_ranking_filters_by_ciiu(db_path):
+    result = await supercias_financials.search_ranking(anio=2025, ciiu_n1="g")
+    assert result["total"] == 1
+    assert result["companias"][0]["expediente"] == 2
+
+
+async def test_search_ranking_rejects_unknown_order_by(db_path):
+    # Falls back to posicion_general instead of raising/injecting SQL.
+    result = await supercias_financials.search_ranking(
+        anio=2025, order_by="DROP TABLE ranking;--"
+    )
+    assert result["total"] == 3
+
+
+async def test_get_sector_benchmark(db_path):
+    benchmark = await supercias_financials.get_sector_benchmark(2025, "c")
+    assert benchmark is not None
+    assert benchmark["descripcion"] == "Manufactura"
+
+    missing = await supercias_financials.get_sector_benchmark(2025, "z")
+    assert missing is None

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -2,8 +2,10 @@ import ssl
 
 from helpers.tls import (
     host_allows_insecure_tls,
+    host_needs_legacy_ciphers,
     insecure_tls_enabled,
     is_cert_verification_error,
+    legacy_cipher_context,
     should_retry_insecure,
 )
 
@@ -35,6 +37,16 @@ def test_host_allowlist_can_be_disabled(monkeypatch):
     assert host_allows_insecure_tls("https://www.datosabiertos.gob.ec/api") is False
 
 
+def test_host_allowlist_includes_supercias(monkeypatch):
+    monkeypatch.setenv("CKAN_INSECURE_TLS", "1")
+    assert (
+        host_allows_insecure_tls(
+            "https://mercadodevalores.supercias.gob.ec/reportes/excel/x.xlsx"
+        )
+        is True
+    )
+
+
 def test_should_retry_insecure(monkeypatch):
     monkeypatch.setenv("CKAN_INSECURE_TLS", "1")
     exc = ssl.SSLCertVerificationError("bad")
@@ -43,3 +55,22 @@ def test_should_retry_insecure(monkeypatch):
         is True
     )
     assert should_retry_insecure(exc, "https://cdn.other.org/x.csv") is False
+
+
+def test_host_needs_legacy_ciphers():
+    assert (
+        host_needs_legacy_ciphers(
+            "https://appscvsmovil.supercias.gob.ec/ranking/recursos/bi_ranking.csv"
+        )
+        is True
+    )
+    assert host_needs_legacy_ciphers("https://cdn.other.org/x.csv") is False
+
+
+def test_legacy_cipher_context_sets_seclevel_1():
+    ctx = legacy_cipher_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    # Still verifies certificates -- this only relaxes cipher strength, not
+    # verification, unlike should_retry_insecure's verify=False fallback.
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -2,9 +2,12 @@ from mcp.server.fastmcp import FastMCP
 
 from tools.download_anda_microdata import register_download_anda_microdata_tool
 from tools.get_anda_survey_info import register_get_anda_survey_info_tool
+from tools.get_auditor_info import register_get_auditor_info_tool
 from tools.get_category_info import register_get_category_info_tool
+from tools.get_compania_info import register_get_compania_info_tool
 from tools.get_contrato_info import register_get_contrato_info_tool
 from tools.get_dataset_info import register_get_dataset_info_tool
+from tools.get_financials import register_get_financials_tool
 from tools.get_institucion_info import register_get_institucion_info_tool
 from tools.get_organization_info import register_get_organization_info_tool
 from tools.get_regulacion_info import register_get_regulacion_info_tool
@@ -20,11 +23,14 @@ from tools.lookup_ubicacion import register_lookup_ubicacion_tool
 from tools.preview_resource_data import register_preview_resource_data_tool
 from tools.query_resource_data import register_query_resource_data_tool
 from tools.search_anda import register_search_anda_tool
+from tools.search_auditores import register_search_auditores_tool
+from tools.search_companias import register_search_companias_tool
 from tools.search_contratos import register_search_contratos_tool
 from tools.search_datasets import register_search_datasets_tool
 from tools.search_ecuador import register_search_ecuador_tool
 from tools.search_eventos_riesgo import register_search_eventos_riesgo_tool
 from tools.search_organizations import register_search_organizations_tool
+from tools.search_ranking import register_search_ranking_tool
 from tools.search_regulaciones import register_search_regulaciones_tool
 from tools.search_sismos import register_search_sismos_tool
 from tools.search_tramites import register_search_tramites_tool
@@ -65,3 +71,10 @@ def register_tools(mcp: FastMCP) -> None:
 
     register_search_contratos_tool(mcp)
     register_get_contrato_info_tool(mcp)
+
+    register_search_companias_tool(mcp)
+    register_get_compania_info_tool(mcp)
+    register_search_ranking_tool(mcp)
+    register_get_financials_tool(mcp)
+    register_search_auditores_tool(mcp)
+    register_get_auditor_info_tool(mcp)

--- a/tools/get_auditor_info.py
+++ b/tools/get_auditor_info.py
@@ -1,0 +1,68 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_get_auditor_info_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def get_auditor_info(identificacion: str, format: str = "text") -> str:
+        """
+        Get full registry details for an authorized external auditor by identificación (Superintendencia de Compañías).
+
+        Returns authorization resolution number/date, nationality, address
+        and contact details. Use search_auditores first if you don't have
+        the exact identificación (RUC/cédula).
+
+        Args:
+            identificacion: The auditor's RUC or cédula
+            format: text | json
+        """
+        try:
+            auditor = await supercias_client.get_auditor_info(identificacion)
+        except Exception as e:
+            return render_output(
+                {"error": str(e), "identificacion": identificacion},
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar el listado de auditores externos: {d['error']}"
+                ),
+            )
+
+        if auditor is None:
+            return render_output(
+                {"error": "not_found", "identificacion": identificacion},
+                format,
+                text_builder=lambda d: (
+                    f"Error: no se encontró ningún auditor externo con "
+                    f"identificación '{d['identificacion']}'. Prueba "
+                    "search_auditores para buscar por nombre."
+                ),
+            )
+
+        def to_text(a: dict) -> str:
+            parts = [
+                f"Auditor externo: {a.get('nombre')}",
+                "",
+                f"Identificación: {a.get('identificacion')}",
+                f"RNAE: {a.get('rnae')}",
+                f"Nacionalidad: {a.get('nacionalidad')}",
+                f"Resolución: {a.get('numero_de_resolucion')} ({a.get('fecha_de_resolucion')})",
+            ]
+            ubicacion = "  ·  ".join(
+                part for part in (a.get("provincia"), a.get("canton")) if part
+            )
+            if ubicacion:
+                parts.append("")
+                parts.append(f"Ubicación: {ubicacion}")
+            if a.get("direccion"):
+                parts.append(f"Dirección: {a['direccion']}")
+            if a.get("telefono"):
+                parts.append(f"Teléfono: {a['telefono']}")
+            if a.get("correo_electronico"):
+                parts.append(f"Correo: {a['correo_electronico']}")
+            return "\n".join(parts)
+
+        return render_output(auditor, format, text_builder=to_text)

--- a/tools/get_compania_info.py
+++ b/tools/get_compania_info.py
@@ -1,0 +1,80 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_get_compania_info_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def get_compania_info(ruc: str, format: str = "text") -> str:
+        """
+        Get full registry details for a company by RUC (Superintendencia de Compañías).
+
+        Returns legal status, incorporation date, legal representative,
+        registered capital, economic activity (CIIU), address and last
+        balance-sheet year. Use search_companias first if you don't have the
+        exact RUC.
+
+        Args:
+            ruc: The company's 13-digit RUC
+            format: text | json
+        """
+        try:
+            compania = await supercias_client.get_compania_by_ruc(ruc)
+        except Exception as e:
+            return render_output(
+                {"error": str(e), "ruc": ruc},
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar el directorio de Supercías: {d['error']}"
+                ),
+            )
+
+        if compania is None:
+            return render_output(
+                {"error": "not_found", "ruc": ruc},
+                format,
+                text_builder=lambda d: (
+                    f"Error: no se encontró ninguna compañía con RUC '{d['ruc']}'. "
+                    "Prueba search_companias para buscar por nombre."
+                ),
+            )
+
+        def to_text(c: dict) -> str:
+            direccion = ", ".join(
+                part
+                for part in (
+                    " ".join(filter(None, [c.get("calle"), c.get("numero")])),
+                    c.get("interseccion"),
+                    c.get("barrio"),
+                    c.get("ciudad"),
+                    c.get("canton"),
+                    c.get("provincia"),
+                )
+                if part
+            )
+            parts = [
+                f"Compañía: {c.get('nombre')}",
+                "",
+                f"RUC: {c.get('ruc')}",
+                f"Expediente: {c.get('expediente')}",
+                f"Situación legal: {c.get('situacion_legal')}",
+                f"Tipo: {c.get('tipo')}",
+                f"Fecha de constitución: {c.get('fecha_constitucion')}",
+            ]
+            if direccion:
+                parts.append("")
+                parts.append(f"Dirección: {direccion}")
+            if c.get("telefono"):
+                parts.append(f"Teléfono: {c['telefono']}")
+            parts.append("")
+            parts.append(f"Representante: {c.get('representante')} ({c.get('cargo')})")
+            parts.append(f"Capital suscrito: {c.get('capital_suscrito')}")
+            parts.append(f"CIIU: {c.get('ciiu_nivel_1')} / {c.get('ciiu_nivel_6')}")
+            if c.get("ultimo_balance"):
+                parts.append(f"Último año de balance presentado: {c['ultimo_balance']}")
+            return "\n".join(parts)
+
+        return render_output(compania, format, text_builder=to_text)

--- a/tools/get_financials.py
+++ b/tools/get_financials.py
@@ -1,0 +1,101 @@
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_financials
+from helpers.format_out import render_output
+from helpers.logging import MAIN_LOGGER_NAME, log_tool
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+_DISPLAY_FIELDS = (
+    ("ingresos_ventas", "Ingresos por ventas"),
+    ("activos", "Activos"),
+    ("patrimonio", "Patrimonio"),
+    ("utilidad_ejercicio", "Utilidad del ejercicio"),
+    ("utilidad_neta", "Utilidad neta"),
+    ("n_empleados", "Empleados"),
+    ("liquidez_corriente", "Liquidez corriente"),
+    ("roe", "ROE"),
+    ("roa", "ROA"),
+    ("end_patrimonial", "Endeudamiento patrimonial"),
+)
+
+
+def register_get_financials_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def get_financials(
+        expediente_or_ruc: str, anio: int | None = None, format: str = "text"
+    ) -> str:
+        """
+        Get a company's financial history from Supercías balance-sheet filings.
+
+        Returns revenue, assets, equity, profit, employee count, and financial
+        ratios (liquidity, leverage, profitability) per fiscal year. Covers
+        only the last few fiscal years (whatever scripts/build_supercias_financials_db.py
+        last cached), not the full history back to 2008. Complements
+        get_compania_info, which has legal/registry data but no financials.
+
+        Args:
+            expediente_or_ruc: The company's Supercías "expediente" number
+                (from search_companias/get_compania_info) or its 13-digit RUC.
+            anio: Optional single fiscal year filter.
+            format: text | json
+        """
+        try:
+            result = await supercias_financials.get_financials(
+                expediente_or_ruc, anio
+            )
+        except supercias_financials.FinancialsDbUnavailable as e:
+            return render_output(
+                {"error": str(e), "expediente_or_ruc": expediente_or_ruc},
+                format,
+                text_builder=lambda d: d["error"],
+            )
+        except Exception as e:
+            logger.exception(
+                "get_financials failed (expediente_or_ruc=%r)", expediente_or_ruc
+            )
+            return render_output(
+                {"error": str(e), "expediente_or_ruc": expediente_or_ruc},
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar los financieros de Supercías: {d['error']}"
+                ),
+            )
+
+        if result.get("error") == "not_found":
+            return render_output(
+                result,
+                format,
+                text_builder=lambda d: (
+                    f"Error: no se encontró ninguna compañía con "
+                    f"'{d['expediente_or_ruc']}'. Prueba search_companias primero."
+                ),
+            )
+
+        def to_text(data: dict) -> str:
+            years = data.get("years") or []
+            header = data.get("nombre") or f"Expediente {data.get('expediente')}"
+            parts = [f"Financieros: {header}"]
+            if data.get("ruc"):
+                parts.append(f"RUC: {data['ruc']}")
+            parts.append(f"Expediente: {data.get('expediente')}")
+            parts.append("")
+            if not years:
+                parts.append(
+                    "Sin datos financieros cacheados para esta compañía "
+                    "(fuera del rango de años disponible, o sin filings)."
+                )
+                return "\n".join(parts)
+            for y in years:
+                parts.append(f"--- Año fiscal {y.get('anio')} ---")
+                for key, label in _DISPLAY_FIELDS:
+                    value = y.get(key)
+                    if value is not None:
+                        parts.append(f"  {label}: {value}")
+                parts.append("")
+            return "\n".join(parts).rstrip()
+
+        return render_output(result, format, text_builder=to_text)

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -5,7 +5,7 @@ from helpers.logging import log_tool
 
 _CAPABILITIES = {
     "name": "Ecuador MCP",
-    "version": "0.5.0",
+    "version": "0.5.4",
     "fuentes": [
         "CKAN datos abiertos",
         "gob.ec trámites/instituciones/regulaciones",
@@ -14,6 +14,9 @@ _CAPABILITIES = {
         "IG-EPN Instituto Geofísico (sismos)",
         "DPA provincias/cantones/parroquias (offline INEC)",
         "ANDA (NADA/IHSN) catálogo de encuestas y censos del INEC",
+        "Supercías directorio de compañías",
+        "Supercías registro de auditores externos autorizados",
+        "Supercías ranking financiero (últimos años, requiere build local)",
     ],
     "entrada": [
         "list_capabilities",
@@ -38,6 +41,13 @@ _CAPABILITIES = {
         "riesgos": ["search_eventos_riesgo", "list_sat_tsunami", "search_sismos"],
         "geo": ["lookup_ubicacion"],
         "encuestas": ["search_anda", "get_anda_survey_info", "download_anda_microdata"],
+        "companias": [
+            "search_companias",
+            "get_compania_info",
+            "search_auditores",
+            "get_auditor_info",
+        ],
+        "financieros": ["search_ranking", "get_financials"],
     },
     "resources": [
         "ecuador://fuentes",
@@ -56,6 +66,16 @@ _CAPABILITIES = {
             "no sustituye canales oficiales de alerta"
         ),
         "lookup_ubicacion(nivel='parroquia') requiere query, canton o provincia",
+        (
+            "search_companias/get_compania_info: primer uso tras expirar el "
+            "caché (6h) puede tardar ~30-40s (descarga y parsea ~35 MB, 226k filas)"
+        ),
+        (
+            "search_ranking/get_financials: requieren que el operador del "
+            "servidor haya corrido scripts/build_supercias_financials_db.py "
+            "de antemano (no se construye solo); cubren solo los últimos "
+            "años cacheados, no el histórico completo desde 2008"
+        ),
     ],
 }
 

--- a/tools/search_auditores.py
+++ b/tools/search_auditores.py
@@ -1,0 +1,88 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_search_auditores_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def search_auditores(
+        query: str = "",
+        provincia: str = "",
+        limit: int = 20,
+        offset: int = 0,
+        format: str = "text",
+    ) -> str:
+        """
+        Search Ecuador's registry of authorized external auditors (Superintendencia de Compañías).
+
+        Covers the 1,447 firms/individuals licensed to act as external
+        auditors, with their authorization resolution number/date and
+        contact details. Source is a daily-refreshed government export,
+        cached up to 6h server-side.
+
+        Args:
+            query: Free text matched against auditor name or identificación
+                (RUC/cédula), accent-insensitive
+            provincia: Optional province filter, e.g. "PICHINCHA" (substring match)
+            limit: Max results (default 20, max 100)
+            offset: Pagination offset over the matched set
+            format: text | json
+        """
+        limit = min(max(limit, 1), 100)
+        offset = max(offset, 0)
+
+        try:
+            result = await supercias_client.search_auditores(
+                query=query,
+                provincia=provincia,
+                limit=limit,
+                offset=offset,
+            )
+        except Exception as e:
+            return render_output(
+                {
+                    "error": str(e),
+                    "query": query or None,
+                    "provincia": provincia or None,
+                },
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar el listado de auditores externos: {d['error']}"
+                ),
+            )
+
+        def to_text(data: dict) -> str:
+            auditores = data.get("auditores") or []
+            parts = [
+                (
+                    f"Auditores Externos — {data['total']} resultado(s) "
+                    f"(mostrando {len(auditores)}, offset={data['offset']})"
+                ),
+                "",
+            ]
+            if not auditores:
+                parts.append("Sin resultados.")
+                return "\n".join(parts)
+            for i, a in enumerate(auditores, 1):
+                parts.append(f"{i}. {a.get('nombre')}")
+                parts.append(f"   Identificación: {a.get('identificacion')}")
+                if a.get("provincia") or a.get("canton"):
+                    ubicacion = "  ·  ".join(
+                        part
+                        for part in (a.get("provincia"), a.get("canton"))
+                        if part
+                    )
+                    parts.append(f"   {ubicacion}")
+                if a.get("numero_de_resolucion"):
+                    parts.append(
+                        f"   Resolución: {a['numero_de_resolucion']} "
+                        f"({a.get('fecha_de_resolucion')})"
+                    )
+                parts.append("")
+            parts.append(f"Fuente: {data.get('url_fuente')}")
+            return "\n".join(parts)
+
+        return render_output(result, format, text_builder=to_text)

--- a/tools/search_companias.py
+++ b/tools/search_companias.py
@@ -1,0 +1,94 @@
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_client
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_search_companias_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def search_companias(
+        query: str = "",
+        provincia: str = "",
+        situacion_legal: str = "",
+        limit: int = 20,
+        offset: int = 0,
+        format: str = "text",
+    ) -> str:
+        """
+        Search Ecuador's company registry (Superintendencia de Compañías).
+
+        Covers 226k+ companies with legal status, incorporation date, legal
+        representative, registered capital, economic activity (CIIU) and
+        address. Source is a daily-refreshed government export, cached up to
+        6h server-side — the first call after the cache expires can take
+        ~30-40s to download and parse (~35 MB, 226k rows).
+
+        Args:
+            query: Free text matched against company name or RUC (accent-insensitive)
+            provincia: Optional province filter, e.g. "PICHINCHA" (substring match)
+            situacion_legal: Optional legal status filter, e.g. "ACTIVA", "DISOLUCIÓN"
+            limit: Max results (default 20, max 100)
+            offset: Pagination offset over the matched set
+            format: text | json
+        """
+        limit = min(max(limit, 1), 100)
+        offset = max(offset, 0)
+
+        try:
+            result = await supercias_client.search_companias(
+                query=query,
+                provincia=provincia,
+                situacion_legal=situacion_legal,
+                limit=limit,
+                offset=offset,
+            )
+        except Exception as e:
+            return render_output(
+                {
+                    "error": str(e),
+                    "query": query or None,
+                    "provincia": provincia or None,
+                    "situacion_legal": situacion_legal or None,
+                },
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar el directorio de Supercías: {d['error']}"
+                ),
+            )
+
+        def to_text(data: dict) -> str:
+            companias = data.get("companias") or []
+            parts = [
+                (
+                    f"Directorio de Compañías — {data['total']} resultado(s) "
+                    f"(mostrando {len(companias)}, offset={data['offset']})"
+                ),
+                "",
+            ]
+            if not companias:
+                parts.append("Sin resultados.")
+                return "\n".join(parts)
+            for i, c in enumerate(companias, 1):
+                parts.append(f"{i}. {c.get('nombre')}")
+                parts.append(f"   RUC: {c.get('ruc')}")
+                parts.append(f"   Situación legal: {c.get('situacion_legal')}")
+                tipo_provincia = [
+                    f"Tipo: {c['tipo']}" if c.get("tipo") else "",
+                    f"Provincia: {c['provincia']}" if c.get("provincia") else "",
+                ]
+                tipo_provincia = [part for part in tipo_provincia if part]
+                if tipo_provincia:
+                    parts.append("   " + "  ·  ".join(tipo_provincia))
+                if c.get("representante"):
+                    parts.append(
+                        f"   Representante: {c['representante']} ({c.get('cargo')})"
+                    )
+                if c.get("capital_suscrito"):
+                    parts.append(f"   Capital suscrito: {c['capital_suscrito']}")
+                parts.append("")
+            parts.append(f"Fuente: {data.get('url_fuente')}")
+            return "\n".join(parts)
+
+        return render_output(result, format, text_builder=to_text)

--- a/tools/search_ranking.py
+++ b/tools/search_ranking.py
@@ -1,0 +1,108 @@
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from helpers import supercias_financials
+from helpers.format_out import render_output
+from helpers.logging import MAIN_LOGGER_NAME, log_tool
+
+logger = logging.getLogger(MAIN_LOGGER_NAME)
+
+
+def register_search_ranking_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def search_ranking(
+        anio: int | None = None,
+        ciiu_n1: str = "",
+        order_by: str = "posicion_general",
+        limit: int = 20,
+        offset: int = 0,
+        format: str = "text",
+    ) -> str:
+        """
+        Rank/filter Supercías companies by financial indicators for a fiscal year.
+
+        Filter by year and/or CIIU level-1 economic activity (single letter,
+        e.g. "C" for manufacturing), sorted by any indicator column (defaults
+        to the dataset's own precomputed posicion_general). Each result
+        includes the company's nombre/ruc alongside its financials. Covers
+        only the last few cached fiscal years, not the full history. Use
+        get_financials for one company's full detail, or get_compania_info
+        for legal/registry data (address, legal representative, etc.).
+
+        Args:
+            anio: Optional fiscal year filter.
+            ciiu_n1: Optional CIIU level-1 filter, e.g. "C", "G", "I".
+            order_by: Column to sort ascending by (e.g. "posicion_general",
+                "activos", "roe"). Falls back to posicion_general if unknown.
+            limit: Max results (default 20, max 100).
+            offset: Pagination offset.
+            format: text | json
+        """
+        limit = min(max(limit, 1), 100)
+        offset = max(offset, 0)
+
+        try:
+            result = await supercias_financials.search_ranking(
+                anio=anio,
+                ciiu_n1=ciiu_n1,
+                order_by=order_by,
+                limit=limit,
+                offset=offset,
+            )
+        except supercias_financials.FinancialsDbUnavailable as e:
+            return render_output(
+                {"error": str(e), "anio": anio, "ciiu_n1": ciiu_n1 or None},
+                format,
+                text_builder=lambda d: d["error"],
+            )
+        except Exception as e:
+            logger.exception(
+                "search_ranking failed (anio=%r, ciiu_n1=%r)", anio, ciiu_n1
+            )
+            return render_output(
+                {"error": str(e), "anio": anio, "ciiu_n1": ciiu_n1 or None},
+                format,
+                text_builder=lambda d: (
+                    f"Error al consultar el ranking de Supercías: {d['error']}"
+                ),
+            )
+
+        def to_text(data: dict) -> str:
+            companias = data.get("companias") or []
+            parts = [
+                (
+                    f"Ranking Supercías — {data['total']} resultado(s) "
+                    f"(mostrando {len(companias)}, offset={data['offset']})"
+                ),
+                "",
+            ]
+            if not companias:
+                parts.append("Sin resultados.")
+                return "\n".join(parts)
+            for i, c in enumerate(companias, 1):
+                nombre = c.get("nombre") or f"Expediente {c.get('expediente')}"
+                parts.append(
+                    f"{i}. {nombre} — año {c.get('anio')} "
+                    f"— posición {c.get('posicion_general')}"
+                )
+                if c.get("ruc"):
+                    parts.append(f"   RUC: {c['ruc']}  ·  Expediente: {c.get('expediente')}")
+                else:
+                    parts.append(f"   Expediente: {c.get('expediente')}")
+                parts.append(f"   CIIU: {c.get('ciiu_n1')} / {c.get('ciiu_n6')}")
+                if c.get("ingresos_ventas") is not None:
+                    parts.append(f"   Ingresos por ventas: {c['ingresos_ventas']}")
+                if c.get("activos") is not None:
+                    parts.append(f"   Activos: {c['activos']}")
+                if c.get("roe") is not None:
+                    parts.append(f"   ROE: {c['roe']}")
+                parts.append("")
+            parts.append(
+                "Tip: usa get_financials(expediente_or_ruc=...) para el detalle "
+                "completo de una compañía."
+            )
+            return "\n".join(parts)
+
+        return render_output(result, format, text_builder=to_text)


### PR DESCRIPTION
## Resumen

Integración completa de la Superintendencia de Compañías (Supercías), tres
datasets del mismo host/institución presentados juntos porque se
complementan entre sí:

### 1. Directorio de compañías (`search_companias`/`get_compania_info`)

El directorio nacional de compañías (226k+, actualizado a diario) —
situación legal, representante legal, capital suscrito, CIIU, dirección.
Export Excel estático descargable de una sola vez, sin auth ni paginación
(`mercadodevalores.supercias.gob.ec/reportes/excel/directorio_companias.xlsx`).

`helpers/supercias_client.py` parsea el archivo con `ElementTree.iterparse`
en vez de openpyxl estándar — el `<dimension>` del archivo viene mal
declarado y rompe el modo `read_only` de openpyxl, que se detiene después
de una fila. Cacheado en memoria 6h; el parseo (CPU-bound) corre en
`asyncio.to_thread` para no bloquear el event loop mientras hay clientes
HTTP concurrentes.

### 2. Ranking financiero (`search_ranking`/`get_financials`)

Segundo dataset de Supercías, mucho más grande: `bi_ranking.csv` (~356 MB
/ ~9M filas) — ingresos, activos, patrimonio y ~38 ratios financieros
(liquidez, endeudamiento, rentabilidad) por compañía y año fiscal, desde
balances reales.

`helpers/supercias_financials.py` solo *consulta* un SQLite local que
`scripts/build_supercias_financials_db.py` arma de antemano (recortado a
los últimos 5 años fiscales, autoajustable — no hardcodeado). Ese SQLite
tiene su propia tabla `companias` (expediente/ruc/nombre, cargada de
`bi_compania.csv`) para resolver nombre/RUC sin depender del directorio,
que se cachea y refresca por separado (diario vs. semanal/manual). El
build es atómico: construye en `<db>.building`, corre verificación de
integridad y columnas requeridas, y recién entonces reemplaza la base que
ya funciona — un build fallido nunca la deja sin datos.

`helpers/tls.py` gana `legacy_cipher_context()` para el handshake TLS de
`appscvsmovil.supercias.gob.ec` (host distinto del directorio) — exige un
mínimo de cifrado que OpenSSL 3 rechaza por defecto; mecanismo separado
del fallback de certificados vencidos que ya existe en este archivo.

### 3. Registro de auditores externos (`search_auditores`/`get_auditor_info`)

Tercer dataset, en el mismo host que el directorio: el registro de
firmas/personas autorizadas para actuar como auditores externos (1,447
filas, ~190 KB, mismo patrón de refresco diario/sin auth). `_parse_xlsx`
se generalizó para aceptar `header_markers` configurables, ya que este
export usa `IDENTIFICACION` como columna de identificación en vez de
`RUC`.

## Verificación

- `uv run ruff check .` limpio, `uv run pytest tests/` — 96/96.
- Probado en vivo contra los tres archivos reales del portal en distintos
  momentos de esta sesión: directorio (226,289 compañías), ranking
  (659,757 filas cargadas, 2021-2025), auditores (1,447 registros,
  búsqueda por provincia y por identificación exacta).
- `main.py` registra los 34 tools sin errores.

## Nota sobre el historial de este PR

Este PR empezó con un scope más chico y fue creciendo con trabajo
adicional (endurecimiento de seguridad genérico, integración de otra
fuente de datos completamente distinta) que no debió haberse apilado
aquí. Ese trabajo ahora vive en PRs propios:
[#7](https://github.com/DweskZ/EcuDataMCP/pull/7) (Banco Central del
Ecuador) y [#8](https://github.com/DweskZ/EcuDataMCP/pull/8) (guardia
SSRF, `uv.lock`, Dockerfile, CI) — ambos independientes de este y entre
sí. Esta rama se reconstruyó desde `main` para que el diff de este PR
vuelva a mostrar solo lo que el título promete.