### PR TITLE
Prompt explorar_tema, tool download_resource, y verificación e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - Prompt MCP `explorar_tema`: exploración temática transversal (datasets,
   trámites, regulaciones, contratos y riesgos) en una sola guía, en vez de
   requerir un prompt por fuente
+- `preview_resource_data` rechaza `.rar` con un mensaje explícito
+  (`rar_no_soportado`) en vez de caer en el genérico "formato no soportado"
+
+### Decided
+- `.rar` y `.xls` legacy: rechazo definitivo en `preview_resource_data`, no
+  se va a implementar soporte (evita la dependencia del binario `unrar`;
+  `.xls` ya se pedía convertir a XLSX)
 
 ## 0.5.1 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Prompt MCP `explorar_tema`: exploración temática transversal (datasets,
+  trámites, regulaciones, contratos y riesgos) en una sola guía, en vez de
+  requerir un prompt por fuente
+
 ## 0.5.1 — 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,31 @@
 - Prompt MCP `explorar_tema`: exploración temática transversal (datasets,
   trámites, regulaciones, contratos y riesgos) en una sola guía, en vez de
   requerir un prompt por fuente
-- Tool `download_resource(resource_id)`: baja el archivo crudo de un
-  recurso en base64 (máx. 5 MB, mismo límite que `preview_resource_data`)
-  para formatos que no se pueden previsualizar como tabla — pensado sobre
-  todo para `.rar` y `.xls` legacy, pero sirve para cualquier resource_id
-- `preview_resource_data` señala `.rar` explícitamente (`rar_no_soportado`,
-  antes caía en el genérico "formato no soportado") y tanto ese mensaje
-  como el de `.xls` (`xls_no_soportado`) ahora apuntan a `download_resource`
+- Tool `download_resource(resource_id, format="json")`: baja el archivo
+  crudo de un recurso en base64 (máx. 5 MB, mismo límite que
+  `preview_resource_data`) para formatos que no se pueden previsualizar
+  como tabla — pensado sobre todo para `.rar`, `.tar.gz` y `.xls` legacy,
+  pero sirve para cualquier resource_id. `format="text"` (el default) solo
+  confirma la descarga; hace falta `format="json"` para recibir
+  `content_base64`
+- `preview_resource_data` señala `.rar`, `.tar.gz` y `.xls` explícitamente
+  (`rar_no_soportado`, `tar_gz_no_soportado`, `xls_no_soportado`, antes
+  algunos de estos caían en el genérico "formato no soportado" o incluso
+  se intentaban parsear como CSV — ver fix debajo), y esos mensajes apuntan
+  a `download_resource`
+
+### Fixed
+- `preview_resource_data` evaluaba el `format` declarado por CKAN *antes*
+  que la extensión de la URL del recurso. Un recurso declarado `CSV` en
+  CKAN pero servido como `.tar.gz` o `.xlsx` (ambos casos reales,
+  encontrados en SRI y MPCEIP durante la verificación e2e) terminaba
+  enviado al parser de CSV en vez de a un mensaje de error o al parser
+  correcto. Ahora una extensión de URL reconocible tiene prioridad sobre
+  un `format` declarado inconsistente
+- Límite de descarga de 5 MB inconsistente: el chequeo de `Content-Length`
+  usaba `>` pero el acumulador de bytes en streaming usaba `>=`, así que un
+  archivo de exactamente 5 MB podía marcarse como truncado pese a que la
+  documentación dice "máx. 5 MB". Ambos chequeos ahora usan `>`
 
 ## 0.5.1 — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 - Prompt MCP `explorar_tema`: exploración temática transversal (datasets,
   trámites, regulaciones, contratos y riesgos) en una sola guía, en vez de
   requerir un prompt por fuente
-- `preview_resource_data` rechaza `.rar` con un mensaje explícito
-  (`rar_no_soportado`) en vez de caer en el genérico "formato no soportado"
-
-### Decided
-- `.rar` y `.xls` legacy: rechazo definitivo en `preview_resource_data`, no
-  se va a implementar soporte (evita la dependencia del binario `unrar`;
-  `.xls` ya se pedía convertir a XLSX)
+- Tool `download_resource(resource_id)`: baja el archivo crudo de un
+  recurso en base64 (máx. 5 MB, mismo límite que `preview_resource_data`)
+  para formatos que no se pueden previsualizar como tabla — pensado sobre
+  todo para `.rar` y `.xls` legacy, pero sirve para cualquier resource_id
+- `preview_resource_data` señala `.rar` explícitamente (`rar_no_soportado`,
+  antes caía en el genérico "formato no soportado") y tanto ese mensaje
+  como el de `.xls` (`xls_no_soportado`) ahora apuntan a `download_resource`
 
 ## 0.5.1 — 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (28 tools)
+## Herramientas disponibles (29 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 
@@ -267,6 +267,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `list_dataset_resources` | Listar todos los archivos (recursos) de un dataset con formato, tamaño, URL y fechas de creación/modificación. |
 | `get_resource_info` | Información detallada de un archivo específico. |
 | `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON o XLSX como tabla (máx. 5 MB). |
+| `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, `.xls` legacy, etc.). |
 | `query_resource_data` | Consulta tabular vía CKAN DataStore (filtros, texto, paginación) sin descargar el archivo. |
 
 ### Trámites Gubernamentales

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 
 ### Prompts MCP
 
-Plantillas listas para el cliente (Claude/Cursor): `explorar_datos`, `consultar_tramite`, `investigar_contrato`, `buscar_regulacion`, `monitorear_riesgos`.
+Plantillas listas para el cliente (Claude/Cursor): `explorar_datos`, `explorar_tema`, `consultar_tramite`, `investigar_contrato`, `buscar_regulacion`, `monitorear_riesgos`.
 
 ### Resources MCP
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ uv run python main.py --transport stdio
 
 ---
 
-## Herramientas disponibles (29 tools)
+## Herramientas disponibles
 
 Casi todos los tools aceptan `format="json"` además de texto.
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `list_dataset_resources` | Listar todos los archivos (recursos) de un dataset con formato, tamaño, URL y fechas de creación/modificación. |
 | `get_resource_info` | Información detallada de un archivo específico. |
 | `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON o XLSX como tabla (máx. 5 MB). |
-| `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, `.xls` legacy, etc.). |
+| `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, `.tar.gz`, `.xls` legacy, etc.). Usa `format="json"` para recibir `content_base64`. |
 | `query_resource_data` | Consulta tabular vía CKAN DataStore (filtros, texto, paginación) sin descargar el archivo. |
 
 ### Trámites Gubernamentales

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,21 +73,27 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
 - [ ] **Tool `read_pdf(url, pages)`** — no hay soporte para leer PDFs del
       portal. Pocos casos hoy, pero es el desbloqueo para fuentes curadas más
       adelante.
-- [ ] **Prompts de flujo de trabajo adicionales** (`@mcp.prompt()`) — hoy solo
-      hay uno; falta al menos un segundo prompt guiado para exploración
-      temática (ej. "explorar_tema").
-- [ ] **Descartar columnas de geometría/WKT** antes de renderizar previews de
-      GeoJSON/CSV — una sola columna de polígono puede inundar el contexto de
-      un preview. `preview_json`/`preview_csv` no lo hacen hoy.
-- [ ] **Parseo de decimales en formato europeo** (`7.760,2` = 7760.20) —
-      común en varios recursos del portal; falta detectarlo y ofrecer
-      conversión, no solo advertir.
-- [ ] **Soporte `.rar`** — decisión pendiente: implementarlo (necesita binario
-      `unrar`) o documentar el rechazo como definitivo.
+- [x] **Prompts de flujo de trabajo adicionales** (`@mcp.prompt()`) — agregado
+      `explorar_tema`, guía transversal a todas las fuentes (datasets,
+      trámites, regulaciones, contratos, riesgos) en una sola pasada.
+- [x] **Descartar columnas de geometría/WKT** antes de renderizar previews de
+      GeoJSON/CSV — ya hecho (ver CHANGELOG 0.5.1): `preview_json`/`preview_csv`
+      descartan columnas de geometría/WKT detectadas por nombre o contenido.
+      Este ítem había quedado desactualizado en el roadmap.
+- [x] **Parseo de decimales en formato europeo** (`7.760,2` = 7760.20) — ya
+      hecho (ver CHANGELOG 0.5.1): se detecta y convierte a notación estándar
+      en CSV. Este ítem había quedado desactualizado en el roadmap.
+- [x] **Soporte `.rar`** — **decidido: rechazo definitivo, sin implementar.**
+      No vale la pena la dependencia del binario `unrar` para el volumen de
+      casos que se ve hoy. `preview_resource_data` ahora devuelve un mensaje
+      explícito (`rar_no_soportado`) con el link de descarga directa, en vez
+      de caer en el genérico "formato no soportado".
 - [ ] **Recursos sin extensión** — requieren sniffing de content-type; sin
       implementar ni probar.
-- [ ] **Soporte `.xls` legacy** — hoy `preview_resource_data` lo rechaza
-      explícitamente; decidir si vale la pena soportarlo.
+- [x] **Soporte `.xls` legacy** — **decidido: rechazo definitivo, sin
+      implementar.** Ya estaba así en el código (`xls_no_soportado`, pide
+      convertir a XLSX o descargar); este ítem solo formaliza que es
+      intencional, no un pendiente por resolver.
 
 ## Verificación end-to-end pendiente
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,31 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       suficiente valor estructurado como para justificar un
       `read_pdf`/extracción dedicada, o si conviene esperar al pendiente
       general de `read_pdf(url, pages)`.
+- [~] **SENESCYT** — pedido explícitamente por Daniel. Datos de educación
+      superior, becas, registro de títulos. **Revisado 2026-08-16: ya
+      reachable hoy, sin código nuevo,** vía los tools CKAN genéricos
+      (`organization="secretaria-de-educacion-superior-ciencia-tecnologia-e-innovacion-senescyt"`
+      en `datosabiertos.gob.ec`) — 13 datasets: matrícula de universidades
+      particulares (UEP) 2015-2023, docentes de UEP 2015-2022, oferta
+      académica de las IES, artículos en revistas indexadas, y varias
+      versiones fechadas de la base de becarios (agosto 2024, marzo 2024,
+      diciembre 2023, agosto 2023, sin fecha ×2) — esta última con
+      versiones repetidas sugiere que conviene usar solo la más reciente o
+      investigar si son acumulativas. **Ojo, no cubre registro de títulos**
+      (lo pedido explícitamente por Daniel) — ese dato no aparece en el
+      CKAN. Portal propio también encontrado, "Portal de Indicadores de
+      Educación Superior" (SIAU,
+      `https://siau.senescyt.gob.ec/portal-de-indicadores-de-educacion-superior/`)
+      — WordPress con 5 secciones temáticas (Estudiantes, Oferta Académica,
+      Docentes, Títulos, Becas, ej. `/indicador-docentes/`), pero **cada
+      sección es un dashboard de Power BI embebido**
+      (`app.powerbi.com/view?r=...`), no una API ni archivos descargables —
+      mismo problema que Superbancos: visual-only, sin endpoint consultable
+      programáticamente. Si el registro de títulos vive en algún lado
+      estructurado, probablemente sea ahí (sección "Títulos" del SIAU) o en
+      un portal de verificación de títulos aparte, todavía sin identificar
+      — pendiente investigar específicamente eso, ya que el CKAN no lo
+      resuelve.
 - [ ] **Cuenca en Datos** (`https://cuencaendatos.cuenca.gob.ec`) — CKAN 2.9.6,
       92 datasets, portal municipal independiente del nacional. Sin probar.
 - [ ] **Sitios de ministerios individuales** — sin alcance definido; falta

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,21 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       `search_eventos_riesgo` y `list_sat_tsunami`, y si falta, diseñar una
       conexión dedicada. Búsqueda quedada interrumpida sin retomar.
 - [ ] **Ecuador en Cifras / portal BI del INEC** — sin investigar todavía.
+- [~] **IESS (Instituto Ecuatoriano de Seguridad Social)** — **agregado
+      2026-08-16, pedido por Daniel: tienen boletines/reportes en PDF en su
+      propio portal.** Ya reachable hoy vía CKAN genérico
+      (`organization="instituto-ecuatoriano-de-seguridad-social"`) — 3
+      datasets: afiliados activos del Seguro General Obligatorio y Régimen
+      Especial Voluntario, pagos y beneficiarios del Seguro de Desempleo
+      (verificado en la sección de verificación e2e de abajo), encuesta
+      familiar del Seguro Social Campesino. **Sin confirmar todavía:** los
+      PDFs (boletines estadísticos) que Daniel menciona — una revisión
+      rápida de `iess.gob.ec/es/estadisticas` no encontró links `.pdf` en el
+      HTML plano (puede ser contenido cargado por JS, o vivir en otra
+      sección del sitio); falta investigar a fondo dónde están y si tienen
+      suficiente valor estructurado como para justificar un
+      `read_pdf`/extracción dedicada, o si conviene esperar al pendiente
+      general de `read_pdf(url, pages)`.
 - [ ] **Cuenca en Datos** (`https://cuencaendatos.cuenca.gob.ec`) — CKAN 2.9.6,
       92 datasets, portal municipal independiente del nacional. Sin probar.
 - [ ] **Sitios de ministerios individuales** — sin alcance definido; falta
@@ -91,6 +106,15 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       (base64, hasta 5 MB) para que se pueda usar fuera del MCP.
 - [ ] **Recursos sin extensión** — requieren sniffing de content-type; sin
       implementar ni probar.
+- [ ] **Soporte `.tar.gz`** — encontrado real durante la verificación e2e
+      (2026-08-16): el dataset `contribuyentes-activos-catastro-2025` del
+      SRI (declarado formato CSV en CKAN) en realidad se descarga como
+      `sri_activos_2025.tar.gz`. Hoy `preview_resource_data` no lo reconoce
+      (ni siquiera está en la lista de "conocidos mal soportados" junto a
+      `.rar`/`.xls`) y cae en el genérico "formato no soportado" —
+      `download_resource` sí lo baja crudo. Descomprimirlo (`tarfile`,
+      stdlib, sin dependencia nueva) y previsualizar el CSV interno sería
+      relativamente simple si se decide hacerlo.
 - [~] **Soporte `.xls` legacy** — `preview_resource_data` sigue sin parsear
       `.xls` como tabla (`xls_no_soportado`), pero ahora se puede bajar el
       archivo completo con `download_resource(resource_id)` para abrirlo
@@ -103,14 +127,36 @@ Cifras de referencia contra el mismo portal (`www.datosabiertos.gob.ec`),
 para confirmar que los tools devuelven los números correctos, no solo que no
 truenan:
 
-- [ ] **SRI** `contribuyentes-activos-catastro-2025` → 2,904,355
+- [x] **SRI** `contribuyentes-activos-catastro-2025` → 2,904,355
       contribuyentes en el mes más reciente vía `sum(TOTAL)`, **no**
-      `count(*)` (que da 405,794).
-- [ ] **IESS** `base-de-datos-seguro-desempleo`, junio 2026 → 2,561
+      `count(*)` (que da 405,794). **Verificado 2026-08-16 contra el portal
+      real (con VPN a LatAm, ver nota de bloqueo geográfico):** cifras
+      exactas — noviembre (mes más reciente) `sum(TOTAL)` = 2,904,355,
+      `count(*)` total = 405,794. **Hallazgo nuevo:** el único recurso CSV
+      del dataset (`sri_activos_2025.csv`) en realidad se descarga como
+      `sri_activos_2025.tar.gz` (5.4 MB comprimido) — `preview_resource_data`
+      no soporta `.tar.gz` hoy (ver pendiente nuevo arriba).
+- [x] **IESS** `base-de-datos-seguro-desempleo`, junio 2026 → 2,561
       beneficiarios, USD 836,716.99, excluyendo la fila `TOTAL:` embebida en
-      el archivo (incluirla da exactamente el doble).
-- [ ] **MPCEIP** cacao → junio 2026, Grado 1 semanal: 174.77 / 168.15 /
-      166.28 / 188.07, usando solo el archivo más reciente.
+      el archivo (incluirla da exactamente el doble). **Verificado
+      2026-08-16:** cifras exactas. **Hallazgo nuevo:** el dataset tiene
+      *dos* recursos distintos con nombres casi idénticos para el mismo mes
+      ("Pagos Desempleo Junio 2026" y "Numero de beneficiarios y montos
+      pagados... a Junio 2026") — el primero es un resumen mensual acumulado
+      del año completo (una fila por mes desde enero), el segundo es el
+      detalle por provincia/género con la fila `TOTAL:` real. Mismo tipo de
+      ambigüedad de nombres que ya motivó el pendiente de detección
+      acumulado-vs-incremental — confirma que ese pendiente sigue siendo
+      necesario, no es un caso aislado.
+- [x] **MPCEIP** cacao → junio 2026, Grado 1 semanal: 174.77 / 168.15 /
+      166.28 / 188.07, usando solo el archivo más reciente. **Verificado
+      2026-08-16:** cifras exactas contra
+      `6.-MPCEIP_PRECIO_FOB_EXPORTACIONES-CACAO_JUN_2026.xlsx`. **Hallazgo
+      nuevo:** ese recurso está declarado `format: CSV` en la metadata de
+      CKAN pero la URL real es `.xlsx` — `preview_resource_data` ya
+      resuelve esto bien porque tiene fallback por extensión de URL cuando
+      el formato declarado no calza, pero confirma que confiar solo en el
+      campo `format` de CKAN no alcanza.
 - [ ] Cobertura real de formatos: `.xls`, `.zip`, `.rar` y una URL sin
       extensión, probados de punta a punta.
 - [ ] Degradación cuando el portal no responde — confirmar que el error que

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,28 +98,34 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
 - [x] **Parseo de decimales en formato europeo** (`7.760,2` = 7760.20) — ya
       hecho (ver CHANGELOG 0.5.1): se detecta y convierte a notación estándar
       en CSV. Este ítem había quedado desactualizado en el roadmap.
-- [~] **Soporte `.rar`** — todavía sin preview como tabla (necesitaría el
-      binario `unrar` como dependencia externa; puerta abierta si el volumen
-      de casos lo justifica). Mientras tanto, `preview_resource_data` señala
-      el caso explícitamente (`rar_no_soportado`) y ahora hay un tool nuevo,
-      `download_resource(resource_id)`, que baja el archivo completo
-      (base64, hasta 5 MB) para que se pueda usar fuera del MCP.
+- [~] **Soporte `.rar`** — todavía sin preview como tabla (necesitaría una
+      dependencia/backend externo para extracción RAR, p. ej. `rarfile` con
+      `unrar`/`unar`/7-Zip/`bsdtar`; puerta abierta si el volumen de casos
+      lo justifica). Mientras tanto, `preview_resource_data` señala el caso
+      explícitamente (`rar_no_soportado`) y ahora hay un tool nuevo,
+      `download_resource(resource_id, format="json")`, que baja el archivo
+      completo (base64, hasta 5 MB) para que se pueda usar fuera del MCP.
 - [ ] **Recursos sin extensión** — requieren sniffing de content-type; sin
       implementar ni probar.
-- [ ] **Soporte `.tar.gz`** — encontrado real durante la verificación e2e
-      (2026-08-16): el dataset `contribuyentes-activos-catastro-2025` del
-      SRI (declarado formato CSV en CKAN) en realidad se descarga como
-      `sri_activos_2025.tar.gz`. Hoy `preview_resource_data` no lo reconoce
-      (ni siquiera está en la lista de "conocidos mal soportados" junto a
-      `.rar`/`.xls`) y cae en el genérico "formato no soportado" —
-      `download_resource` sí lo baja crudo. Descomprimirlo (`tarfile`,
-      stdlib, sin dependencia nueva) y previsualizar el CSV interno sería
-      relativamente simple si se decide hacerlo.
+- [x] **Detección de `.tar.gz`** — encontrado real durante la verificación
+      e2e (2026-08-16): el dataset `contribuyentes-activos-catastro-2025`
+      del SRI (declarado formato CSV en CKAN) en realidad se descarga como
+      `sri_activos_2025.tar.gz`. **Corregido 2026-08-17:** el bug real era
+      que `preview_resource_data` confiaba en el `format` declarado por
+      CKAN *antes* que en la extensión de la URL, así que un `.tar.gz`
+      declarado CSV terminaba enviado al parser de CSV en vez de cualquier
+      mensaje de error. Ahora la extensión de URL (cuando es reconocible)
+      tiene prioridad sobre el `format` declarado, y `.tar.gz` tiene su
+      propio caso (`tar_gz_no_soportado`) que apunta a `download_resource`.
+      Sigue pendiente: **previsualizar el contenido** del `.tar.gz`
+      (descomprimir con `tarfile`, stdlib, sin dependencia nueva, y mostrar
+      el CSV interno) — hoy solo se detecta y se ofrece la descarga cruda.
 - [~] **Soporte `.xls` legacy** — `preview_resource_data` sigue sin parsear
       `.xls` como tabla (`xls_no_soportado`), pero ahora se puede bajar el
-      archivo completo con `download_resource(resource_id)` para abrirlo
-      localmente. Preview real (vía `xlrd`, que es pura Python, sin binario
-      externo) queda como posible siguiente paso si hace falta.
+      archivo completo con `download_resource(resource_id, format="json")`
+      para abrirlo localmente. Preview real (vía `xlrd`, que es pura
+      Python, sin binario externo) queda como posible siguiente paso si
+      hace falta.
 
 ## Verificación end-to-end pendiente
 
@@ -135,7 +141,9 @@ truenan:
       `count(*)` total = 405,794. **Hallazgo nuevo:** el único recurso CSV
       del dataset (`sri_activos_2025.csv`) en realidad se descarga como
       `sri_activos_2025.tar.gz` (5.4 MB comprimido) — `preview_resource_data`
-      no soporta `.tar.gz` hoy (ver pendiente nuevo arriba).
+      ahora lo detecta correctamente (ver ítem `.tar.gz` arriba), pero
+      todavía no lo previsualiza como tabla, solo lo ofrece vía
+      `download_resource`.
 - [x] **IESS** `base-de-datos-seguro-desempleo`, junio 2026 → 2,561
       beneficiarios, USD 836,716.99, excluyendo la fila `TOTAL:` embebida en
       el archivo (incluirla da exactamente el doble). **Verificado
@@ -153,10 +161,13 @@ truenan:
       2026-08-16:** cifras exactas contra
       `6.-MPCEIP_PRECIO_FOB_EXPORTACIONES-CACAO_JUN_2026.xlsx`. **Hallazgo
       nuevo:** ese recurso está declarado `format: CSV` en la metadata de
-      CKAN pero la URL real es `.xlsx` — `preview_resource_data` ya
-      resuelve esto bien porque tiene fallback por extensión de URL cuando
-      el formato declarado no calza, pero confirma que confiar solo en el
-      campo `format` de CKAN no alcanza.
+      CKAN pero la URL real es `.xlsx`. **Corrección 2026-08-17:** a pesar
+      de lo que decía esta nota antes, `preview_resource_data` *no*
+      resolvía esto — el `format` declarado (`CSV`) se evaluaba antes que
+      la extensión de la URL, así que este recurso también terminaba en el
+      parser de CSV en vez del de XLSX. Mismo fix que el caso `.tar.gz` del
+      SRI arriba: ahora la extensión de URL tiene prioridad. Confirma que
+      confiar solo en el campo `format` de CKAN no alcanza.
 - [ ] Cobertura real de formatos: `.xls`, `.zip`, `.rar` y una URL sin
       extensión, probados de punta a punta.
 - [ ] Degradación cuando el portal no responde — confirmar que el error que

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,17 +83,19 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
 - [x] **Parseo de decimales en formato europeo** (`7.760,2` = 7760.20) — ya
       hecho (ver CHANGELOG 0.5.1): se detecta y convierte a notación estándar
       en CSV. Este ítem había quedado desactualizado en el roadmap.
-- [x] **Soporte `.rar`** — **decidido: rechazo definitivo, sin implementar.**
-      No vale la pena la dependencia del binario `unrar` para el volumen de
-      casos que se ve hoy. `preview_resource_data` ahora devuelve un mensaje
-      explícito (`rar_no_soportado`) con el link de descarga directa, en vez
-      de caer en el genérico "formato no soportado".
+- [~] **Soporte `.rar`** — todavía sin preview como tabla (necesitaría el
+      binario `unrar` como dependencia externa; puerta abierta si el volumen
+      de casos lo justifica). Mientras tanto, `preview_resource_data` señala
+      el caso explícitamente (`rar_no_soportado`) y ahora hay un tool nuevo,
+      `download_resource(resource_id)`, que baja el archivo completo
+      (base64, hasta 5 MB) para que se pueda usar fuera del MCP.
 - [ ] **Recursos sin extensión** — requieren sniffing de content-type; sin
       implementar ni probar.
-- [x] **Soporte `.xls` legacy** — **decidido: rechazo definitivo, sin
-      implementar.** Ya estaba así en el código (`xls_no_soportado`, pide
-      convertir a XLSX o descargar); este ítem solo formaliza que es
-      intencional, no un pendiente por resolver.
+- [~] **Soporte `.xls` legacy** — `preview_resource_data` sigue sin parsear
+      `.xls` como tabla (`xls_no_soportado`), pero ahora se puede bajar el
+      archivo completo con `download_resource(resource_id)` para abrirlo
+      localmente. Preview real (vía `xlrd`, que es pura Python, sin binario
+      externo) queda como posible siguiente paso si hace falta.
 
 ## Verificación end-to-end pendiente
 

--- a/helpers/csv_reader.py
+++ b/helpers/csv_reader.py
@@ -121,7 +121,7 @@ async def _download(session: httpx.AsyncClient, url: str) -> tuple[bytes, bool]:
         async for chunk in resp.aiter_bytes(chunk_size=64 * 1024):
             chunks.append(chunk)
             total += len(chunk)
-            if total >= MAX_DOWNLOAD_BYTES:
+            if total > MAX_DOWNLOAD_BYTES:
                 truncated = True
                 break
 

--- a/prompts/workflows.py
+++ b/prompts/workflows.py
@@ -71,6 +71,31 @@ def register_workflow_prompts(mcp: FastMCP) -> None:
         )
 
     @mcp.prompt(
+        name="explorar_tema",
+        title="Explorar un tema a través de todas las fuentes",
+        description="Guía para recorrer datasets, trámites, regulaciones, contratos y riesgos de un tema en una sola pasada.",
+    )
+    def explorar_tema(tema: str = "empleo") -> str:
+        """Prompt para exploración temática transversal a todas las fuentes del MCP."""
+        return (
+            f"Quiero un panorama completo sobre '{tema}' en Ecuador, cruzando "
+            "todas las fuentes disponibles en este MCP.\n"
+            f"1) Empieza con search_ecuador('{tema}') para ver qué hay en cada fuente "
+            "(datasets, trámites, regulaciones, contratos, riesgos) de un vistazo.\n"
+            "2) Si hay datasets relevantes, profundiza con get_dataset_info y "
+            "list_dataset_resources; usa query_resource_data o preview_resource_data "
+            "para traer cifras concretas.\n"
+            "3) Si hay trámites relacionados, usa get_tramite_info para requisitos y costos.\n"
+            "4) Si hay regulaciones o contratos públicos relevantes, detállalos con "
+            "get_regulacion_info / get_contrato_info.\n"
+            "5) Si el tema toca riesgos o emergencias, revisa search_eventos_riesgo "
+            "o search_sismos según aplique.\n"
+            "Organiza la respuesta en español por fuente (Datos Abiertos, Trámites, "
+            "Regulaciones, Contratos, Riesgos), citando IDs y URLs, y omite las "
+            "secciones sin resultados relevantes."
+        )
+
+    @mcp.prompt(
         name="monitorear_riesgos",
         title="Monitorear riesgos / emergencias",
         description="Guía para consultar eventos SGR COE y estaciones SAT tsunami.",

--- a/tests/test_csv_reader.py
+++ b/tests/test_csv_reader.py
@@ -1,4 +1,9 @@
-from helpers.csv_reader import normalize_eu_decimal_columns, strip_geometry_columns
+from helpers.csv_reader import (
+    MAX_DOWNLOAD_BYTES,
+    download_bytes,
+    normalize_eu_decimal_columns,
+    strip_geometry_columns,
+)
 
 
 def test_strip_geometry_columns_by_name():
@@ -65,3 +70,22 @@ def test_normalize_eu_decimal_columns_leaves_ambiguous_columns():
 
     assert converted == []
     assert new_rows == rows
+
+
+async def test_download_bytes_exactly_at_limit_is_not_truncated(httpx_mock):
+    body = b"x" * MAX_DOWNLOAD_BYTES
+    httpx_mock.add_response(url="https://x/exact.bin", content=body)
+
+    content, truncated = await download_bytes("https://x/exact.bin")
+
+    assert len(content) == MAX_DOWNLOAD_BYTES
+    assert truncated is False
+
+
+async def test_download_bytes_over_limit_is_truncated(httpx_mock):
+    body = b"x" * (MAX_DOWNLOAD_BYTES + 1)
+    httpx_mock.add_response(url="https://x/over.bin", content=body)
+
+    _content, truncated = await download_bytes("https://x/over.bin")
+
+    assert truncated is True

--- a/tests/test_download_resource.py
+++ b/tests/test_download_resource.py
@@ -1,0 +1,116 @@
+import base64
+import json
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+import tools.download_resource as download_resource_module
+from helpers import ckan_client
+from helpers.csv_reader import MAX_DOWNLOAD_BYTES
+from tools.download_resource import register_download_resource_tool
+
+
+def _make_tool():
+    mcp = FastMCP("test")
+    register_download_resource_tool(mcp)
+    return mcp._tool_manager.get_tool("download_resource").fn
+
+
+def _mock_resource(
+    monkeypatch, *, url="https://x/archivo.rar", fmt="RAR", name="Archivo"
+):
+    async def fake_get_resource(resource_id, session=None):
+        return {"url": url, "format": fmt, "name": name}
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+
+async def test_json_format_returns_base64_roundtrip(monkeypatch):
+    raw = b"\x50\x4b\x03\x04binary-ish-content"
+
+    async def fake_download_bytes(url, session=None):
+        return raw, False
+
+    _mock_resource(monkeypatch)
+    monkeypatch.setattr(download_resource_module, "download_bytes", fake_download_bytes)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+
+    assert base64.b64decode(payload["content_base64"]) == raw
+    assert payload["size_bytes"] == len(raw)
+
+
+async def test_text_format_does_not_leak_base64_and_points_to_json(monkeypatch):
+    raw = b"some bytes"
+
+    async def fake_download_bytes(url, session=None):
+        return raw, False
+
+    _mock_resource(monkeypatch)
+    monkeypatch.setattr(download_resource_module, "download_bytes", fake_download_bytes)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="text")
+
+    # The actual encoded payload must not leak in text mode, only a
+    # pointer to format="json" for retrieving it.
+    assert base64.b64encode(raw).decode("ascii") not in result
+    assert 'format="json"' in result
+
+
+async def test_resource_not_found(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        request = httpx.Request("GET", "https://x/resource_show")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("not found", request=request, response=response)
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="missing", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "not_found"
+
+
+async def test_resource_without_url(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {"format": "RAR", "name": "Sin URL"}
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "sin_url"
+
+
+async def test_download_http_error(monkeypatch):
+    async def fake_download_bytes(url, session=None):
+        raise httpx.ConnectError("boom")
+
+    _mock_resource(monkeypatch)
+    monkeypatch.setattr(download_resource_module, "download_bytes", fake_download_bytes)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert "download_failed" in payload["error"]
+
+
+async def test_oversized_file_has_no_content_base64_and_keeps_direct_url(monkeypatch):
+    async def fake_download_bytes(url, session=None):
+        return b"x" * 100, True
+
+    _mock_resource(monkeypatch, url="https://x/enorme.zip", fmt="ZIP")
+    monkeypatch.setattr(download_resource_module, "download_bytes", fake_download_bytes)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+
+    assert payload["error"] == "demasiado_grande"
+    assert "content_base64" not in payload
+    assert payload["url"] == "https://x/enorme.zip"
+    assert payload["max_bytes"] == MAX_DOWNLOAD_BYTES

--- a/tests/test_preview_resource_data.py
+++ b/tests/test_preview_resource_data.py
@@ -1,0 +1,165 @@
+import json
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+import tools.preview_resource_data as preview_resource_data_module
+from helpers import ckan_client
+from tools.preview_resource_data import (
+    classify_resource_format,
+    register_preview_resource_data_tool,
+)
+
+
+def _make_tool():
+    mcp = FastMCP("test")
+    register_preview_resource_data_tool(mcp)
+    return mcp._tool_manager.get_tool("preview_resource_data").fn
+
+
+# -- classify_resource_format ------------------------------------------------
+
+
+def test_classify_by_extension_wins_over_conflicting_declared_format():
+    # Real case found during e2e verification: SRI declares CSV in CKAN but
+    # actually serves the resource as .tar.gz.
+    assert (
+        classify_resource_format("CSV", "https://x/sri_activos_2025.tar.gz") == "TARGZ"
+    )
+    # Real case found during e2e verification: MPCEIP declares CSV in CKAN
+    # but the resource is actually .xlsx.
+    assert classify_resource_format("CSV", "https://x/precios_cacao.xlsx") == "XLSX"
+
+
+def test_classify_rar_by_extension_even_if_declared_csv():
+    assert classify_resource_format("CSV", "https://x/archivo.rar") == "RAR"
+
+
+def test_classify_falls_back_to_declared_format_without_recognizable_extension():
+    assert classify_resource_format("RAR", "https://x/download?id=123") == "RAR"
+    assert classify_resource_format("XLS", "https://x/download?id=123") == "XLS"
+    assert classify_resource_format("JSON", "https://x/download?id=123") == "JSON"
+    assert classify_resource_format("CSV", "https://x/download?id=123") == "CSV"
+    # No format declared and no recognizable extension: same "assume CSV"
+    # default the tool has always used (empty format is treated as CSV).
+    assert classify_resource_format("", "https://x/download?id=123") == "CSV"
+    assert classify_resource_format("ZIP", "https://x/download?id=123") == "UNKNOWN"
+
+
+def test_classify_plain_csv():
+    assert classify_resource_format("CSV", "https://x/datos.csv") == "CSV"
+    assert classify_resource_format("", "https://x/datos.csv") == "CSV"
+
+
+def test_classify_legacy_xls_distinct_from_xlsx():
+    assert classify_resource_format("", "https://x/reporte.xls") == "XLS"
+    assert classify_resource_format("", "https://x/reporte.xlsx") == "XLSX"
+
+
+def test_classify_json_and_geojson():
+    assert classify_resource_format("", "https://x/datos.json") == "JSON"
+    assert classify_resource_format("", "https://x/mapa.geojson") == "JSON"
+
+
+# -- dispatch through the tool ------------------------------------------------
+
+
+async def test_sri_tar_gz_declared_csv_is_not_sent_to_csv_parser(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {
+            "url": "https://sri.example/sri_activos_2025.tar.gz",
+            "format": "CSV",
+            "name": "SRI activos",
+        }
+
+    async def fail_preview_csv(*args, **kwargs):
+        raise AssertionError("preview_csv should not be called for a .tar.gz resource")
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(preview_resource_data_module, "preview_csv", fail_preview_csv)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "tar_gz_no_soportado"
+
+
+async def test_mpceip_xlsx_declared_csv_is_routed_to_xlsx_parser(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {
+            "url": "https://mpceip.example/precios_cacao.xlsx",
+            "format": "CSV",
+            "name": "Precios cacao",
+        }
+
+    calls = []
+
+    async def fake_preview_xlsx(url, max_rows=20, session=None):
+        calls.append(url)
+        return {
+            "headers": ["producto", "precio"],
+            "rows": [["cacao", "174.77"]],
+            "total_rows_in_preview": 1,
+        }
+
+    async def fail_preview_csv(*args, **kwargs):
+        raise AssertionError("preview_csv should not be called for a .xlsx resource")
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(preview_resource_data_module, "preview_xlsx", fake_preview_xlsx)
+    monkeypatch.setattr(preview_resource_data_module, "preview_csv", fail_preview_csv)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["headers"] == ["producto", "precio"]
+    assert calls == ["https://mpceip.example/precios_cacao.xlsx"]
+
+
+async def test_rar_message_does_not_overclaim_unrar_requirement(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {"url": "https://x/archivo.rar", "format": "RAR", "name": "Archivo"}
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="text")
+    assert "unrar" not in result
+    assert "download_resource('abc123', format=\"json\")" in result
+
+
+async def test_xls_message_points_to_download_resource_with_json_format(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {"url": "https://x/reporte.xls", "format": "XLS", "name": "Reporte"}
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="text")
+    assert "download_resource('abc123', format=\"json\")" in result
+
+
+async def test_resource_not_found_returns_error(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        request = httpx.Request("GET", "https://x/resource_show")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("not found", request=request, response=response)
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="missing", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "not_found"
+
+
+async def test_resource_without_url_returns_error(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {"format": "CSV", "name": "Sin URL"}
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "sin_url"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,6 +1,7 @@
 from mcp.server.fastmcp import FastMCP
 
 from tools.download_anda_microdata import register_download_anda_microdata_tool
+from tools.download_resource import register_download_resource_tool
 from tools.get_anda_survey_info import register_get_anda_survey_info_tool
 from tools.get_category_info import register_get_category_info_tool
 from tools.get_contrato_info import register_get_contrato_info_tool
@@ -45,6 +46,7 @@ def register_tools(mcp: FastMCP) -> None:
     register_list_dataset_resources_tool(mcp)
     register_get_resource_info_tool(mcp)
     register_preview_resource_data_tool(mcp)
+    register_download_resource_tool(mcp)
     register_query_resource_data_tool(mcp)
     register_search_organizations_tool(mcp)
     register_get_organization_info_tool(mcp)

--- a/tools/download_resource.py
+++ b/tools/download_resource.py
@@ -1,0 +1,106 @@
+import base64
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+from helpers import ckan_client
+from helpers.csv_reader import MAX_DOWNLOAD_BYTES, download_bytes
+from helpers.format_out import render_output
+from helpers.logging import log_tool
+
+
+def register_download_resource_tool(mcp: FastMCP) -> None:
+    @mcp.tool()
+    @log_tool
+    async def download_resource(resource_id: str, format: str = "text") -> str:
+        """
+        Download a resource's raw bytes from Ecuador's open data portal, base64-encoded.
+
+        Use this for formats preview_resource_data can't parse into a table
+        (.rar, legacy .xls, or anything unrecognized) — it fetches the file
+        as-is instead of trying to read it. Max size: 5 MB (same cap as
+        preview_resource_data). Larger files come back with an error and the
+        direct URL instead, since they'd be too big to embed in a response.
+
+        Args:
+            resource_id: The resource UUID (get it from list_dataset_resources)
+            format: text | json (json includes content_base64)
+        """
+        try:
+            res = await ckan_client.get_resource(resource_id)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return render_output(
+                    {"error": "not_found", "resource_id": resource_id},
+                    format,
+                    text_builder=lambda d: (
+                        f"Error: Recurso con ID '{d['resource_id']}' no encontrado."
+                    ),
+                )
+            return render_output(
+                {"error": f"HTTP {e.response.status_code}", "detail": str(e)},
+                format,
+                text_builder=lambda d: f"Error: {d['error']} - {d['detail']}",
+            )
+        except Exception as e:
+            return render_output(
+                {"error": str(e)},
+                format,
+                text_builder=lambda d: f"Error al obtener metadata del recurso: {d['error']}",
+            )
+
+        url = res.get("url")
+        if not url:
+            return render_output(
+                {"error": "sin_url", "resource_id": resource_id},
+                format,
+                text_builder=lambda _: "Error: Este recurso no tiene URL de descarga.",
+            )
+
+        name = res.get("name") or res.get("description") or "Sin título"
+        fmt = (res.get("format") or "").upper() or None
+
+        try:
+            content, truncated = await download_bytes(url)
+        except httpx.HTTPError as e:
+            return render_output(
+                {"error": f"download_failed: {e}", "url": url},
+                format,
+                text_builder=lambda d: f"Error al descargar el archivo: {d['error']}",
+            )
+
+        if truncated:
+            max_mb = MAX_DOWNLOAD_BYTES // (1024 * 1024)
+            return render_output(
+                {
+                    "error": "demasiado_grande",
+                    "resource_id": resource_id,
+                    "name": name,
+                    "url": url,
+                    "max_bytes": MAX_DOWNLOAD_BYTES,
+                },
+                format,
+                text_builder=lambda d: (
+                    f"'{d['name']}' supera el límite de {max_mb} MB para descarga "
+                    f"vía MCP. Bájalo directamente desde: {d['url']}"
+                ),
+            )
+
+        payload = {
+            "resource_id": resource_id,
+            "name": name,
+            "url": url,
+            "format": fmt,
+            "size_bytes": len(content),
+            "content_base64": base64.b64encode(content).decode("ascii"),
+        }
+
+        def to_text(data: dict) -> str:
+            return (
+                f"Descargado: {data['name']} ({data['size_bytes']} bytes"
+                f"{', formato ' + data['format'] if data.get('format') else ''}).\n"
+                'Usa format="json" para obtener el contenido en content_base64 '
+                "(decodifícalo en base64 para reconstruir el archivo original)."
+            )
+
+        return render_output(payload, format, text_builder=to_text)

--- a/tools/download_resource.py
+++ b/tools/download_resource.py
@@ -17,14 +17,20 @@ def register_download_resource_tool(mcp: FastMCP) -> None:
         Download a resource's raw bytes from Ecuador's open data portal, base64-encoded.
 
         Use this for formats preview_resource_data can't parse into a table
-        (.rar, legacy .xls, or anything unrecognized) — it fetches the file
-        as-is instead of trying to read it. Max size: 5 MB (same cap as
-        preview_resource_data). Larger files come back with an error and the
-        direct URL instead, since they'd be too big to embed in a response.
+        (.rar, .tar.gz, legacy .xls, or anything unrecognized) — it fetches
+        the file as-is instead of trying to read it. Max size: 5 MB (same
+        cap as preview_resource_data). Larger files come back with an error
+        and the direct URL instead, since they'd be too big to embed in a
+        response.
+
+        Call with format="json" to get the actual file content — the
+        default format="text" only confirms the download and tells you to
+        retry with json; it never includes content_base64.
 
         Args:
             resource_id: The resource UUID (get it from list_dataset_resources)
-            format: text | json (json includes content_base64)
+            format: text | json (json includes content_base64; use this to
+                actually retrieve the file)
         """
         try:
             res = await ckan_client.get_resource(resource_id)

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -71,6 +71,20 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
         name = res.get("name") or res.get("description") or "Sin título"
 
         try:
+            if fmt == "RAR" or url.lower().endswith(".rar"):
+                return render_output(
+                    {
+                        "error": "rar_no_soportado",
+                        "url": url,
+                        "resource_id": resource_id,
+                    },
+                    format,
+                    text_builder=lambda d: (
+                        "Este recurso es un archivo .rar. No lo soportamos "
+                        "(requeriría el binario unrar como dependencia externa). "
+                        f"Descárgalo y extráelo manualmente desde: {d['url']}"
+                    ),
+                )
             if fmt in _CSV_FORMATS or (
                 not fmt and url.lower().endswith((".csv", ".tsv", ".txt"))
             ):

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -80,9 +80,10 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                     },
                     format,
                     text_builder=lambda d: (
-                        "Este recurso es un archivo .rar. No lo soportamos "
-                        "(requeriría el binario unrar como dependencia externa). "
-                        f"Descárgalo y extráelo manualmente desde: {d['url']}"
+                        "Este recurso es un archivo .rar. Todavía no lo previsualizamos como "
+                        "tabla (requeriría el binario unrar como dependencia externa), pero "
+                        f"puedes bajar el archivo completo con download_resource('{d['resource_id']}'), "
+                        f"o directamente desde: {d['url']}"
                     ),
                 )
             if fmt in _CSV_FORMATS or (
@@ -101,8 +102,9 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                         },
                         format,
                         text_builder=lambda d: (
-                            "Este recurso es Excel legacy (.xls). "
-                            f"Convierte a XLSX o descárgalo desde: {d['url']}"
+                            "Este recurso es Excel legacy (.xls), que no previsualizamos como "
+                            f"tabla. Puedes bajarlo con download_resource('{d['resource_id']}') "
+                            f"y abrirlo localmente, o desde: {d['url']}"
                         ),
                     )
                 result = await preview_xlsx(url, max_rows=rows)

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -8,7 +8,42 @@ from helpers.logging import log_tool
 
 _CSV_FORMATS = {"CSV", "TSV", "TXT", ""}
 _JSON_FORMATS = {"JSON", "GEOJSON"}
-_XLSX_FORMATS = {"XLSX", "XLS", "EXCEL"}
+_XLSX_FORMATS = {"XLSX", "EXCEL"}
+
+
+def classify_resource_format(fmt: str, url: str) -> str:
+    """Classify a resource as RAR/TARGZ/XLS/XLSX/JSON/CSV/UNKNOWN.
+
+    CKAN's declared `format` is frequently wrong (e.g. a .tar.gz or .xlsx
+    file tagged "CSV" by whoever published it), so a recognizable URL
+    extension always wins over a conflicting declared format. Only when
+    the extension itself is not diagnostic do we fall back to `fmt`.
+    """
+    url_lower = url.lower()
+    if url_lower.endswith(".rar"):
+        return "RAR"
+    if url_lower.endswith((".tar.gz", ".tgz")):
+        return "TARGZ"
+    if url_lower.endswith(".xlsx"):
+        return "XLSX"
+    if url_lower.endswith(".xls"):
+        return "XLS"
+    if url_lower.endswith((".json", ".geojson")):
+        return "JSON"
+    if url_lower.endswith((".csv", ".tsv", ".txt")):
+        return "CSV"
+
+    if fmt == "RAR":
+        return "RAR"
+    if fmt == "XLS":
+        return "XLS"
+    if fmt in _XLSX_FORMATS:
+        return "XLSX"
+    if fmt in _JSON_FORMATS:
+        return "JSON"
+    if fmt in _CSV_FORMATS:
+        return "CSV"
+    return "UNKNOWN"
 
 
 def register_preview_resource_data_tool(mcp: FastMCP) -> None:
@@ -69,9 +104,10 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
 
         fmt = (res.get("format") or "").upper()
         name = res.get("name") or res.get("description") or "Sin título"
+        kind = classify_resource_format(fmt, url)
 
         try:
-            if fmt == "RAR" or url.lower().endswith(".rar"):
+            if kind == "RAR":
                 return render_output(
                     {
                         "error": "rar_no_soportado",
@@ -81,33 +117,48 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                     format,
                     text_builder=lambda d: (
                         "Este recurso es un archivo .rar. Todavía no lo previsualizamos como "
-                        "tabla (requeriría el binario unrar como dependencia externa), pero "
-                        f"puedes bajar el archivo completo con download_resource('{d['resource_id']}'), "
+                        "tabla (requeriría una dependencia/backend externo para extracción RAR), "
+                        f"pero puedes bajar el archivo completo con "
+                        f"download_resource('{d['resource_id']}', format=\"json\"), "
                         f"o directamente desde: {d['url']}"
                     ),
                 )
-            if fmt in _CSV_FORMATS or (
-                not fmt and url.lower().endswith((".csv", ".tsv", ".txt"))
-            ):
-                result = await preview_csv(url, max_rows=rows)
-            elif fmt in _JSON_FORMATS or url.lower().endswith((".json", ".geojson")):
-                result = await preview_json(url, max_rows=rows)
-            elif fmt in _XLSX_FORMATS or url.lower().endswith((".xlsx", ".xls")):
-                if fmt == "XLS" or url.lower().endswith(".xls"):
-                    return render_output(
-                        {
-                            "error": "xls_no_soportado",
-                            "url": url,
-                            "resource_id": resource_id,
-                        },
-                        format,
-                        text_builder=lambda d: (
-                            "Este recurso es Excel legacy (.xls), que no previsualizamos como "
-                            f"tabla. Puedes bajarlo con download_resource('{d['resource_id']}') "
-                            f"y abrirlo localmente, o desde: {d['url']}"
-                        ),
-                    )
+            if kind == "TARGZ":
+                return render_output(
+                    {
+                        "error": "tar_gz_no_soportado",
+                        "url": url,
+                        "resource_id": resource_id,
+                    },
+                    format,
+                    text_builder=lambda d: (
+                        "Este recurso es un archivo .tar.gz. Todavía no lo previsualizamos "
+                        "como tabla, pero puedes bajar el archivo completo con "
+                        f"download_resource('{d['resource_id']}', format=\"json\"), "
+                        f"o directamente desde: {d['url']}"
+                    ),
+                )
+            if kind == "XLS":
+                return render_output(
+                    {
+                        "error": "xls_no_soportado",
+                        "url": url,
+                        "resource_id": resource_id,
+                    },
+                    format,
+                    text_builder=lambda d: (
+                        "Este recurso es Excel legacy (.xls), que no previsualizamos como "
+                        f"tabla. Puedes bajarlo con "
+                        f"download_resource('{d['resource_id']}', format=\"json\") "
+                        f"y abrirlo localmente, o desde: {d['url']}"
+                    ),
+                )
+            if kind == "XLSX":
                 result = await preview_xlsx(url, max_rows=rows)
+            elif kind == "JSON":
+                result = await preview_json(url, max_rows=rows)
+            elif kind == "CSV":
+                result = await preview_csv(url, max_rows=rows)
             else:
                 return render_output(
                     {


### PR DESCRIPTION
## Resumen

Tres mejoras chicas, independientes entre sí, empaquetadas en un solo PR
por ser todas de bajo alcance (no ameritan PR propio cada una). Parte
directo de `main`, sin depender de Supercías ni de BCE/SRI (PR #9, #7).

1. **Prompt `explorar_tema`** — exploración temática transversal a todas
   las fuentes (datasets, trámites, regulaciones, contratos, riesgos) en
   una sola guía, en vez de requerir un prompt por fuente.
2. **Tool `download_resource(resource_id)`** — baja el archivo crudo de un
   recurso en base64 (máx. 5 MB, mismo límite que `preview_resource_data`)
   para formatos que no se pueden previsualizar como tabla (`.rar`, etc.).
3. **Verificación end-to-end de tres cifras de referencia del roadmap**
   contra el portal real — las tres exactas — más dos hallazgos reales y
   un pendiente de IESS agregado.

## `download_resource`

`.rar` y `.xls` legacy no se pueden previsualizar como tabla sin agregar
una dependencia (binario `unrar`, o `xlrd` para `.xls`), pero eso no
debería significar que el usuario se quede sin poder acceder al archivo.
`download_resource(resource_id)` reusa `download_bytes` (ya existente en
`helpers/csv_reader.py`) y devuelve el archivo completo en base64. El
mensaje de `.rar` en `preview_resource_data` (`rar_no_soportado`, antes
caía en el genérico "formato no soportado") ahora apunta a este tool.

## Verificación e2e

Con acceso real al portal (`www.datosabiertos.gob.ec` — bloquea
geográficamente fuera de LatAm, ya documentado en el README/ROADMAP de
este fork), verifiqué las tres cifras de referencia que ya estaban
anotadas en `ROADMAP.md`:

- **SRI** `contribuyentes-activos-catastro-2025`: `sum(TOTAL)` del mes más
  reciente (Noviembre) = **2,904,355**; `count(*)` total = **405,794**.
  Exacto.
- **IESS** `base-de-datos-seguro-desempleo`, junio 2026: fila `TOTAL:` =
  **$836,716.99** / **2,561** beneficiarios. Exacto.
- **MPCEIP** cacao, junio 2026, Grado 1 semanal: **174.77 / 168.15 /
  166.28 / 188.07**. Exacto.

De paso encontré dos problemas reales, documentados en `ROADMAP.md`:
- El recurso del SRI está declarado `format: CSV` en CKAN pero en
  realidad es un `.tar.gz` — `preview_resource_data` no lo reconoce hoy
  (nuevo pendiente, `tarfile` de la stdlib alcanzaría).
- El dataset de IESS tiene dos recursos con nombres casi idénticos para
  el mismo mes, y solo uno tiene el detalle real por provincia — confirma
  que el pendiente de detección acumulado-vs-incremental es un problema
  recurrente, no un caso aislado.

También agregué IESS como fuente candidata al roadmap (3 datasets ya
alcanzables vía CKAN genérico) y corregí dos ítems del roadmap que habían
quedado desactualizados (descarte de columnas WKT y parseo de decimales
europeos — ambos ya estaban hechos según el propio CHANGELOG, pero
seguían marcados como pendientes).

## Verificación

- `uv run ruff check .` limpio, `uv run pytest` — 57/57.
- `main.py` registra los 29 tools sin errores.
