### PR TITLE
Some more housekeeping

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,14 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       sobre la API pública sin autenticación de BCEData
       (`contenido.bce.fin.ec/wp-json/bcedata/v1/`), no documentada
       oficialmente pero confirmada con `curl` plano.
-- [ ] **Superintendencia de Compañías (Supercías)** — el portal CKAN solo
-      publica 1 dataset; tiene portal propio sin investigar.
+- [x] **Superintendencia de Compañías (Supercías)** — hecho: directorio de
+      compañías (`search_companias`/`get_compania_info`, 226k+ compañías,
+      actualizado a diario, parseado desde el export Excel estático del
+      portal), ranking financiero (`search_ranking`/`get_financials`, ~38
+      ratios financieros por compañía y año fiscal, sobre un SQLite local
+      construido de antemano con `scripts/build_supercias_financials_db.py`)
+      y registro de auditores externos
+      (`search_auditores`/`get_auditor_info`).
 - [ ] **Instituto Geofísico (IG-EPN)** — pedido explícitamente por Daniel.
       Verificar qué cubren ya `search_organizations`, `list_instituciones`,
       `search_eventos_riesgo` y `list_sat_tsunami`, y si falta, diseñar una
@@ -88,13 +94,6 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       `CKAN_INSECURE_TLS` que desactiva la verificación quedó documentado como
       temporal — apagar el default inseguro en cuanto el gobierno renueve el
       certificado.
-- [ ] **Borrar la rama ya mergeada `fix/ckan-domain-and-readme`** (local y en
-      el fork) — el intento quedó bloqueado por el classifier de seguridad;
-      sigue viva sin necesidad.
-- [ ] **Decidir sobre los dos `Manual de Usuarios Portal.pdf` duplicados** en
-      `reference-docs/` del fork de Daniel (395 KB vs 2.5 MB) — nunca se
-      aclaró si son versiones distintas o si uno sobra.
-
 ---
 
 ## Calidad de búsqueda y detección de series
@@ -225,16 +224,4 @@ truenan:
 bloqueo geográfico/upstream era en realidad un bug de vhost — el apex
 `datosabiertos.gob.ec` y el subdominio `presidencia` resuelven a la misma IP
 pero devuelven 403; solo `www.datosabiertos.gob.ec` está conectado. Ya
-corregido en el repo; los 27 tools funcionan.
-
-**Repo hermano:** [`datosec-mcp`](../datosec-mcp) es un MCP propio de Daniel
-sobre la misma fuente de datos (portal CKAN de Ecuador). Su `ROADMAP.md`
-(2026-08-13) era mucho más extenso porque partía de cero: incluía trámites,
-SERCOP, ANDA, SAT tsunami, eventos de riesgo y ubicaciones DPA, que aquí en
-EcuDataMCP ya están resueltos y por eso no se repiten en esta lista. Todo lo
-demás que sí seguía pendiente ahí — búsqueda semántica, expansión de
-consultas, detección acumulado/incremental, formatos de archivo, verificación
-end-to-end y arquitectura — se consolidó arriba en este archivo el
-2026-08-13, y el `ROADMAP.md` de `datosec-mcp` se eliminó para no mantener dos
-listas por separado. Este archivo es ahora la única fuente de pendientes para
-ambos.
+corregido en el repo; los 38 tools funcionan.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,10 +34,8 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       construido de antemano con `scripts/build_supercias_financials_db.py`)
       y registro de auditores externos
       (`search_auditores`/`get_auditor_info`).
-- [ ] **Instituto Geofísico (IG-EPN)** — pedido explícitamente por Daniel.
-      Verificar qué cubren ya `search_organizations`, `list_instituciones`,
-      `search_eventos_riesgo` y `list_sat_tsunami`, y si falta, diseñar una
-      conexión dedicada. Búsqueda quedada interrumpida sin retomar.
+- [x] **Instituto Geofísico (IG-EPN)** — hecho: tool `search_sismos` sobre el
+      catálogo sísmico público, con caché TTL y parseo tolerante del CSV.
 - [ ] **Ecuador en Cifras / portal BI del INEC** — sin investigar todavía.
 - [~] **IESS (Instituto Ecuatoriano de Seguridad Social)** — **agregado
       2026-08-16, pedido por Daniel: tienen boletines/reportes en PDF en su
@@ -94,6 +92,7 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       `CKAN_INSECURE_TLS` que desactiva la verificación quedó documentado como
       temporal — apagar el default inseguro en cuanto el gobierno renueve el
       certificado.
+
 ---
 
 ## Calidad de búsqueda y detección de series


### PR DESCRIPTION
## Resumen

Housekeeping de documentación tras el merge de #7/#8/#9/#10 — corrige varios ítems del `ROADMAP.md` que quedaron desactualizados o que nunca debieron estar ahí:

- **Supercías** seguía marcado `[ ]` sin investigar, aunque #9 (directorio + ranking financiero + auditores externos) ya está mergeado y los 6 tools (`search_companias`, `get_compania_info`, `search_ranking`, `get_financials`, `search_auditores`, `get_auditor_info`) están registrados en `tools/__init__.py`. Lo marco `[x]` con lo que realmente hay.
- **IG-EPN** tenía el mismo problema: decía "búsqueda quedada interrumpida sin retomar" pero `search_sismos` + `helpers/igepn_client.py` están registrados y funcionando desde hace rato. También lo marco `[x]`.
- Quito tres notas que son bookkeeping específico del fork de un contribuidor y no aplican a este repo:
  - borrar una rama que solo existe en su fork personal
  - duplicados de `reference-docs/Manual de Usuarios Portal.pdf` — esa carpeta no existe en este repo
  - nota de "repo hermano" apuntando a un proyecto privado por path relativo (`../datosec-mcp`), que solo tiene sentido en su propia máquina
- Corrijo el conteo de "27 tools funcionan" a 38, el número real hoy en `tools/__init__.py`.
- Restauro una línea en blanco antes de un separador `---` que se me fue en el primer commit de este PR.

## Test plan

Solo cambios de documentación (`ROADMAP.md`); no toca código.
