### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 — 2026-08-18
 
 Integración con el Banco Central del Ecuador (BCEData) y datasets del SRI,
 más integración completa de la Superintendencia de Compañías (Supercías):

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ más abajo.
 
 ---
 
-## Herramientas disponibles
+## Herramientas disponibles (38 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from tools import register_tools
 setup_logging()
 
 SERVER_START_TIME = datetime.now(UTC)
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ecuador-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "Model Context Protocol (MCP) server for Ecuador open government data: CKAN, gob.ec, SERCOP OCDS, SGR risk events, and DPA geography."
 authors = [{ name = "Ecuador MCP Contributors" }]
 readme = "README.md"

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -5,7 +5,7 @@ from helpers.logging import log_tool
 
 _CAPABILITIES = {
     "name": "Ecuador MCP",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "fuentes": [
         "CKAN datos abiertos",
         "gob.ec trámites/instituciones/regulaciones",


### PR DESCRIPTION
## Resumen

Cierra el paso de integración final que quedó pendiente después de mergear #7/#8/#9/#10 (avisado en los comentarios de esos PRs): ninguno de los cuatro se auto-asigna versión desde el fix de coordinación, así que alguien tenía que elegir el número real una sola vez.

- `pyproject.toml`, `main.py`, `tools/list_capabilities.py` → `0.6.0`
- `CHANGELOG.md`: `## Unreleased` → `## 0.6.0 — 2026-08-18`
- `README.md`: heading de tools con el conteo real, `(38 tools)` (antes se había quitado el número a propósito para evitar el choque de merge entre los 4 PRs)

Uso minor y no patch porque el contenido combinado (BCE/SRI, Supercías completo, `explorar_tema`/`download_resource`, endurecimiento SSRF/CI) es una integración de features nueva, no un parche.

## Test plan

- [x] `uv run pytest -q` → 139 passed
- Solo archivos de versión/documentación; no toca lógica de tools.
