### PR TITLE
Release 0.6.0 (con fix de uv.lock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 — 2026-08-18
 
 Integración con el Banco Central del Ecuador (BCEData) y datasets del SRI,
 más integración completa de la Superintendencia de Compañías (Supercías):

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ más abajo.
 
 ---
 
-## Herramientas disponibles
+## Herramientas disponibles (38 tools)
 
 Casi todos los tools aceptan `format="json"` además de texto.
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from tools import register_tools
 setup_logging()
 
 SERVER_START_TIME = datetime.now(UTC)
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 
 logger = logging.getLogger(MAIN_LOGGER_NAME)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ecuador-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "Model Context Protocol (MCP) server for Ecuador open government data: CKAN, gob.ec, SERCOP OCDS, SGR risk events, and DPA geography."
 authors = [{ name = "Ecuador MCP Contributors" }]
 readme = "README.md"

--- a/tools/list_capabilities.py
+++ b/tools/list_capabilities.py
@@ -5,7 +5,7 @@ from helpers.logging import log_tool
 
 _CAPABILITIES = {
     "name": "Ecuador MCP",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "fuentes": [
         "CKAN datos abiertos",
         "gob.ec trámites/instituciones/regulaciones",

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ wheels = [
 
 [[package]]
 name = "ecuador-mcp"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cierra el paso de integración pendiente después de mergear #7/#8/#9/#10:

- `pyproject.toml`, `main.py`, `tools/list_capabilities.py` → `0.6.0`
- `CHANGELOG.md`: `## Unreleased` → `## 0.6.0 — 2026-08-18`
- `README.md`: heading de tools con el conteo real `(38 tools)`
- **`uv.lock`**: actualizado para reflejar la versión 0.6.0 (corrige el fallo de CI del PR #12 original)

Supersede el PR #12 de dsanchezp18, que fallaba CI porque faltaba actualizar el lockfile.

## Test plan
- [x] `uv sync --group dev --locked` OK
- [x] `uv run pytest -q` → 139 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02527-4645-7dda-b50e-e4b988a6df64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02527-4645-7dda-b50e-e4b988a6df64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

