### PR TITLE
Soporte de previsualización para .xls, .tar.gz y .zip en preview_resource_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-Soporte de preview para dos formatos que antes solo se podían descargar
-crudos: Excel legacy (`.xls`) y `.tar.gz` que envuelve un CSV/TSV/TXT.
-Confirmación de renovación del certificado TLS del portal.
+Soporte de preview para tres formatos que antes solo se podían descargar
+crudos: Excel legacy (`.xls`), `.tar.gz` y `.zip` que envuelven un
+CSV/TSV/TXT. Confirmación de renovación del certificado TLS del portal.
 
 ### Added
 - **Soporte `.xls` legacy en `preview_resource_data`**: previsualiza el
@@ -20,11 +20,28 @@ Confirmación de renovación del certificado TLS del portal.
   tope de 20 MB para acotar el impacto de un archivo diseñado para expandirse
   desproporcionadamente al descomprimirlo. Nueva función
   `helpers/csv_reader.preview_targz`.
+- **Soporte `.zip` en `preview_resource_data`**: descomprime el archivo
+  (`zipfile`, stdlib, sin dependencia nueva) y muestra el CSV/TSV/TXT interno
+  como tabla, con la misma prioridad `.csv` > `.tsv` > `.txt` que `.tar.gz`
+  al elegir el miembro. A diferencia de `.tar.gz`, el directorio central de
+  un `.zip` no requiere descomprimir nada para listar los miembros, así que
+  basta con acotar la lectura del miembro elegido (sin el paso de
+  descompresión con tope que sí hace falta para `.tar.gz`). Lógica de
+  selección de miembro extraída a `helpers/csv_reader._pick_member`,
+  compartida entre `preview_targz` y el nuevo `preview_zip`.
 
 ### Fixed
 - Refactor interno: la lógica de parseo de CSV se extrajo a
   `helpers/csv_reader._parse_csv_bytes`, compartida entre `preview_csv` y
   `preview_targz`, sin cambios de comportamiento en `preview_csv`.
+- `preview_targz` no marcaba `truncated=True` cuando el CSV/TSV/TXT interno
+  superaba los 5 MB por sí solo (solo consideraba la descarga y la
+  descompresión externas) — el contenido se cortaba igual, pero el preview
+  no avisaba. Corregido leyendo un byte de más para detectar el corte, igual
+  que ya hacía la descarga original.
+- `tools/download_resource.py`: el docstring seguía listando `.tar.gz` y
+  `.xls` legacy como formatos que hay que descargar crudos, desactualizado
+  desde que `preview_resource_data` empezó a previsualizarlos.
 
 ### Confirmed
 - **Certificado TLS de `www.datosabiertos.gob.ec` renovado** (Let's Encrypt,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+Soporte de preview para dos formatos que antes solo se podían descargar
+crudos: Excel legacy (`.xls`) y `.tar.gz` que envuelve un CSV/TSV/TXT.
+Confirmación de renovación del certificado TLS del portal.
+
+### Added
+- **Soporte `.xls` legacy en `preview_resource_data`**: previsualiza el
+  archivo como tabla vía `xlrd` (pura Python, sin binario externo) en vez de
+  solo señalar `xls_no_soportado` y apuntar a `download_resource`. Nueva
+  función `helpers/csv_reader.preview_xls`, misma forma que `preview_xlsx`.
+- **Previsualización de `.tar.gz` en `preview_resource_data`**: descomprime
+  el archivo (`tarfile` + `zlib`, stdlib, sin dependencia nueva) y muestra el
+  CSV/TSV/TXT interno como tabla. Si el archivo contiene varios miembros,
+  prioriza `.csv` > `.tsv` > `.txt` en vez de tomar el primero del archivo
+  (evita que un `readme.txt` empaquetado gane sobre el dato real — bug real
+  encontrado escribiendo el test de esta función). La descompresión tiene un
+  tope de 20 MB para acotar el impacto de un archivo diseñado para expandirse
+  desproporcionadamente al descomprimirlo. Nueva función
+  `helpers/csv_reader.preview_targz`.
+
+### Fixed
+- Refactor interno: la lógica de parseo de CSV se extrajo a
+  `helpers/csv_reader._parse_csv_bytes`, compartida entre `preview_csv` y
+  `preview_targz`, sin cambios de comportamiento en `preview_csv`.
+
+### Confirmed
+- **Certificado TLS de `www.datosabiertos.gob.ec` renovado** (Let's Encrypt,
+  válido 2026-08-07 a 2026-11-05) — verificado contra el portal real.
+  `CKAN_INSECURE_TLS` ya estaba en su default seguro (`0`) desde antes; no
+  se requirió ningún cambio de código.
+
 ## 0.6.0 — 2026-08-18
 
 Integración con el Banco Central del Ecuador (BCEData) y datasets del SRI,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ En lugar de navegar manualmente por portales gubernamentales, simplemente pregun
 
 - **Acceso instantáneo a datos públicos**: Pregunta en lenguaje natural y obtén datos de 98 instituciones del Estado ecuatoriano sin navegar portales, descargar archivos ni lidiar con formatos.
 - **Unifica múltiples fuentes en un solo punto**: Datos abiertos (CKAN), trámites gubernamentales (gob.ec) y categorías temáticas, todo accesible desde una sola conversación con tu IA.
-- **Preview de datos sin descargas**: `preview_resource_data` parsea CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) y `.tar.gz` (si envuelve un CSV/TSV/TXT) en memoria; `query_resource_data` consulta el DataStore CKAN sin bajar el archivo completo.
+- **Preview de datos sin descargas**: `preview_resource_data` parsea CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) y `.tar.gz`/`.zip` (si envuelven un CSV/TSV/TXT) en memoria; `query_resource_data` consulta el DataStore CKAN sin bajar el archivo completo.
 - **Cero fricción**: No necesitas API key, no necesitas cuenta, no necesitas permisos especiales. 100% datos públicos bajo licencia abierta.
 - **Compatible con cualquier cliente MCP**: Claude, ChatGPT, Gemini, Cursor, VS Code, Windsurf, Le Chat, HuggingChat y más.
 - **Listo para producción**: Docker, health checks, logging estructurado, y un servidor HTTP Streamable que sigue la especificación MCP al pie de la letra.
@@ -294,7 +294,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `get_dataset_info` | Metadata detallada de un dataset: título, descripción, organización, tags, licencia, fechas. |
 | `list_dataset_resources` | Listar todos los archivos (recursos) de un dataset con formato, tamaño, URL y fechas de creación/modificación. |
 | `get_resource_info` | Información detallada de un archivo específico. |
-| `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) o `.tar.gz` (si envuelve un CSV/TSV/TXT) como tabla (máx. 5 MB). |
+| `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) o `.tar.gz`/`.zip` (si envuelven un CSV/TSV/TXT) como tabla (máx. 5 MB). |
 | `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, etc.). Usa `format="json"` para recibir `content_base64`. |
 | `query_resource_data` | Consulta tabular vía CKAN DataStore (filtros, texto, paginación) sin descargar el archivo. |
 | `search_sri_datasets` | Buscar entre ~130 archivos del SRI publicados fuera del portal CKAN (sri.gob.ec/datasets): catastro RUC por provincia, recaudación, ventas/compras, vehículos, CEL, diccionarios de variables. |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ En lugar de navegar manualmente por portales gubernamentales, simplemente pregun
 
 - **Acceso instantáneo a datos públicos**: Pregunta en lenguaje natural y obtén datos de 98 instituciones del Estado ecuatoriano sin navegar portales, descargar archivos ni lidiar con formatos.
 - **Unifica múltiples fuentes en un solo punto**: Datos abiertos (CKAN), trámites gubernamentales (gob.ec) y categorías temáticas, todo accesible desde una sola conversación con tu IA.
-- **Preview de datos sin descargas**: `preview_resource_data` parsea CSV/TSV, JSON/GeoJSON y XLSX en memoria; `query_resource_data` consulta el DataStore CKAN sin bajar el archivo completo.
+- **Preview de datos sin descargas**: `preview_resource_data` parsea CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) y `.tar.gz` (si envuelve un CSV/TSV/TXT) en memoria; `query_resource_data` consulta el DataStore CKAN sin bajar el archivo completo.
 - **Cero fricción**: No necesitas API key, no necesitas cuenta, no necesitas permisos especiales. 100% datos públicos bajo licencia abierta.
 - **Compatible con cualquier cliente MCP**: Claude, ChatGPT, Gemini, Cursor, VS Code, Windsurf, Le Chat, HuggingChat y más.
 - **Listo para producción**: Docker, health checks, logging estructurado, y un servidor HTTP Streamable que sigue la especificación MCP al pie de la letra.
@@ -294,8 +294,8 @@ Casi todos los tools aceptan `format="json"` además de texto.
 | `get_dataset_info` | Metadata detallada de un dataset: título, descripción, organización, tags, licencia, fechas. |
 | `list_dataset_resources` | Listar todos los archivos (recursos) de un dataset con formato, tamaño, URL y fechas de creación/modificación. |
 | `get_resource_info` | Información detallada de un archivo específico. |
-| `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON o XLSX como tabla (máx. 5 MB). |
-| `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, `.tar.gz`, `.xls` legacy, etc.). Usa `format="json"` para recibir `content_base64`. |
+| `preview_resource_data` | Preview de CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) o `.tar.gz` (si envuelve un CSV/TSV/TXT) como tabla (máx. 5 MB). |
+| `download_resource` | Baja el archivo crudo de un recurso en base64 (máx. 5 MB) — para formatos que no se pueden previsualizar como tabla (`.rar`, etc.). Usa `format="json"` para recibir `content_base64`. |
 | `query_resource_data` | Consulta tabular vía CKAN DataStore (filtros, texto, paginación) sin descargar el archivo. |
 | `search_sri_datasets` | Buscar entre ~130 archivos del SRI publicados fuera del portal CKAN (sri.gob.ec/datasets): catastro RUC por provincia, recaudación, ventas/compras, vehículos, CEL, diccionarios de variables. |
 
@@ -462,7 +462,7 @@ Cliente MCP (Claude, ChatGPT, Cursor, etc.)
 │   ├── search_ecuador         │  → CKAN + gob.ec (unificado)
 │   ├── search_datasets        │
 │   ├── query_resource_data    │  → CKAN DataStore
-│   ├── preview_resource_data  │  → CSV / JSON / XLSX
+│   ├── preview_resource_data  │  → CSV / JSON / XLS / XLSX
 │   ├── get_category_info      │  → helpers/ckan_client.py
 │   ├── search_tramites        │
 │   ├── get_institucion_info   │  → helpers/gobec_client.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,6 +161,16 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       solo devolvía `xls_no_soportado` con un puntero a `download_resource`;
       ahora usa `helpers/csv_reader.preview_xls`, misma forma que
       `preview_xlsx`.
+- [x] **Soporte `.zip`** — hecho: `preview_resource_data` descomprime el
+      `.zip` (`zipfile`, stdlib, sin dependencia nueva) y muestra el
+      CSV/TSV/TXT interno como tabla, con la misma prioridad `.csv` > `.tsv`
+      > `.txt` que `.tar.gz`. A diferencia de `.tar.gz`, el directorio
+      central de un `.zip` lista los miembros sin descomprimir nada, así que
+      no hace falta un paso de descompresión con tope por adelantado —
+      basta con acotar la lectura del único miembro elegido para evitar que
+      un archivo diseñado para expandirse desproporcionadamente agote
+      memoria. Lógica de selección de miembro compartida con `.tar.gz` vía
+      `helpers/csv_reader._pick_member`.
 
 ## Verificación end-to-end pendiente
 
@@ -203,8 +213,11 @@ truenan:
       parser de CSV en vez del de XLSX. Mismo fix que el caso `.tar.gz` del
       SRI arriba: ahora la extensión de URL tiene prioridad. Confirma que
       confiar solo en el campo `format` de CKAN no alcanza.
-- [ ] Cobertura real de formatos: `.xls`, `.zip`, `.rar` y una URL sin
-      extensión, probados de punta a punta.
+- [ ] Cobertura real de formatos contra el portal en vivo: `.xls`, `.zip` y
+      una URL sin extensión, probados de punta a punta (hoy `.xls`/`.zip`
+      solo tienen cobertura con archivos sintéticos en los tests, no contra
+      un recurso real del portal). `.rar` queda fuera porque sigue sin
+      preview (ver ítem de soporte `.rar` arriba).
 - [ ] Degradación cuando el portal no responde — confirmar que el error que
       recibe el modelo es accionable (indica el host correcto), no genérico.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,11 +87,12 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
 
 ## Cabos operativos sueltos
 
-- [ ] **Revisar renovación del certificado TLS** de
-      `www.datosabiertos.gob.ec` (venció 2026-07-28). El fallback
-      `CKAN_INSECURE_TLS` que desactiva la verificación quedó documentado como
-      temporal — apagar el default inseguro en cuanto el gobierno renueve el
-      certificado.
+- [x] **Renovación del certificado TLS** de `www.datosabiertos.gob.ec` (había
+      vencido 2026-07-28). **Confirmado 2026-08-22 contra el portal real:**
+      certificado renovado (Let's Encrypt, válido 2026-08-07 a 2026-11-05).
+      `CKAN_INSECURE_TLS` ya vuelve a su default seguro (`0`, desactivado) —
+      ver `helpers/tls.py`. Próximo corte de renovación: antes de
+      2026-11-05.
 
 ---
 
@@ -147,16 +148,19 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       declarado CSV terminaba enviado al parser de CSV en vez de cualquier
       mensaje de error. Ahora la extensión de URL (cuando es reconocible)
       tiene prioridad sobre el `format` declarado, y `.tar.gz` tiene su
-      propio caso (`tar_gz_no_soportado`) que apunta a `download_resource`.
-      Sigue pendiente: **previsualizar el contenido** del `.tar.gz`
-      (descomprimir con `tarfile`, stdlib, sin dependencia nueva, y mostrar
-      el CSV interno) — hoy solo se detecta y se ofrece la descarga cruda.
-- [~] **Soporte `.xls` legacy** — `preview_resource_data` sigue sin parsear
-      `.xls` como tabla (`xls_no_soportado`), pero ahora se puede bajar el
-      archivo completo con `download_resource(resource_id, format="json")`
-      para abrirlo localmente. Preview real (vía `xlrd`, que es pura
-      Python, sin binario externo) queda como posible siguiente paso si
-      hace falta.
+      propio caso. **Previsualización de contenido agregada:**
+      `preview_resource_data` descomprime el `.tar.gz` (`tarfile` + `zlib`,
+      stdlib, sin dependencia nueva) y muestra el CSV/TSV/TXT interno como
+      tabla — si hay varios archivos dentro, prioriza `.csv` > `.tsv` >
+      `.txt` en vez del primero del archivo (evita que un `readme.txt`
+      empaquetado gane sobre el dato real). La descompresión tiene un tope
+      de 20 MB para acotar el impacto de un archivo diseñado para expandirse
+      desproporcionadamente al descomprimirlo.
+- [x] **Soporte `.xls` legacy** — hecho: `preview_resource_data` previsualiza
+      `.xls` como tabla vía `xlrd` (pura Python, sin binario externo). Antes
+      solo devolvía `xls_no_soportado` con un puntero a `download_resource`;
+      ahora usa `helpers/csv_reader.preview_xls`, misma forma que
+      `preview_xlsx`.
 
 ## Verificación end-to-end pendiente
 

--- a/helpers/csv_reader.py
+++ b/helpers/csv_reader.py
@@ -3,6 +3,8 @@ import io
 import json
 import logging
 import re
+import tarfile
+import zlib
 from typing import Any
 
 import httpx
@@ -177,16 +179,7 @@ def _decode_text(raw: bytes) -> str:
     return raw.decode("utf-8", errors="replace")
 
 
-async def preview_csv(
-    url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
-) -> dict[str, Any]:
-    """
-    Download a CSV file and return the first N rows parsed.
-
-    Returns:
-        dict with 'headers', 'rows', 'total_rows_in_preview', 'truncated'
-    """
-    raw, truncated = await download_bytes(url, session=session)
+def _parse_csv_bytes(raw: bytes, max_rows: int, truncated: bool = False) -> dict[str, Any]:
     text = _decode_text(raw)
 
     sample = text[:2000]
@@ -204,7 +197,7 @@ async def preview_csv(
             break
 
     if not rows_read:
-        return {"headers": [], "rows": [], "total_rows_in_preview": 0, "truncated": False}
+        return {"headers": [], "rows": [], "total_rows_in_preview": 0, "truncated": truncated}
 
     headers = rows_read[0]
     data_rows = rows_read[1 : max_rows + 1]
@@ -217,12 +210,26 @@ async def preview_csv(
         "rows": data_rows,
         "total_rows_in_preview": len(data_rows),
         "truncated": truncated,
-        "format": "csv",
     }
     if dropped_geom:
         result["dropped_columns"] = dropped_geom
     if converted_decimals:
         result["converted_decimal_columns"] = converted_decimals
+    return result
+
+
+async def preview_csv(
+    url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
+) -> dict[str, Any]:
+    """
+    Download a CSV file and return the first N rows parsed.
+
+    Returns:
+        dict with 'headers', 'rows', 'total_rows_in_preview', 'truncated'
+    """
+    raw, truncated = await download_bytes(url, session=session)
+    result = _parse_csv_bytes(raw, max_rows, truncated=truncated)
+    result["format"] = "csv"
     return result
 
 
@@ -365,6 +372,111 @@ async def preview_xlsx(
         }
     finally:
         wb.close()
+
+
+async def preview_xls(
+    url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
+) -> dict[str, Any]:
+    """Preview the first sheet of a legacy Excel (.xls) workbook."""
+    import xlrd
+
+    raw, truncated = await download_bytes(url, session=session)
+    wb = xlrd.open_workbook(file_contents=raw)
+    ws = wb.sheet_by_index(0)
+
+    if ws.nrows == 0:
+        return {
+            "headers": [],
+            "rows": [],
+            "total_rows_in_preview": 0,
+            "truncated": truncated,
+            "format": "xls",
+        }
+
+    def cell_str(value: Any) -> str:
+        return "" if value is None else str(value)
+
+    headers = [cell_str(v) for v in ws.row_values(0)]
+    data_rows: list[list[str]] = []
+    for i in range(1, ws.nrows):
+        if len(data_rows) >= max_rows:
+            truncated = True
+            break
+        data_rows.append([cell_str(v) for v in ws.row_values(i)])
+
+    return {
+        "headers": headers,
+        "rows": data_rows,
+        "total_rows_in_preview": len(data_rows),
+        "truncated": truncated,
+        "format": "xls",
+        "sheet": ws.name,
+    }
+
+
+_MAX_DECOMPRESSED_BYTES = 20 * 1024 * 1024  # 20 MB
+
+
+def _gunzip_capped(raw: bytes, cap: int = _MAX_DECOMPRESSED_BYTES) -> tuple[bytes, bool]:
+    """Decompress gzip bytes, stopping once `cap` output bytes are produced.
+
+    Bounds memory use against a decompression bomb: a small, highly
+    compressible .tar.gz (already capped at MAX_DOWNLOAD_BYTES on the wire)
+    could otherwise expand to gigabytes once decompressed.
+    """
+    decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    out = bytearray()
+    chunk_size = 64 * 1024
+    for i in range(0, len(raw), chunk_size):
+        out += decompressor.decompress(raw[i : i + chunk_size])
+        if len(out) > cap:
+            return bytes(out[:cap]), True
+    out += decompressor.flush()
+    return bytes(out[:cap]), len(out) > cap
+
+
+async def preview_targz(
+    url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
+) -> dict[str, Any]:
+    """Preview the first CSV/TSV-like member inside a .tar.gz archive."""
+    raw, truncated = await download_bytes(url, session=session)
+    decompressed, capped = _gunzip_capped(raw)
+    truncated = truncated or capped
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:") as tar:
+            members = [m for m in tar.getmembers() if m.isfile()]
+            if not members:
+                return {
+                    "headers": [],
+                    "rows": [],
+                    "total_rows_in_preview": 0,
+                    "truncated": truncated,
+                    "format": "tar_gz",
+                }
+            # Prefer .csv over .tsv over .txt: a bundled readme.txt should not
+            # win over the actual data file just because it comes first.
+            member = None
+            for ext in (".csv", ".tsv", ".txt"):
+                member = next(
+                    (m for m in members if m.name.lower().endswith(ext)), None
+                )
+                if member is not None:
+                    break
+            if member is None:
+                member = members[0]
+            extracted = tar.extractfile(member)
+            inner_raw = extracted.read(MAX_DOWNLOAD_BYTES) if extracted else b""
+    except tarfile.TarError as e:
+        raise ValueError(
+            "El archivo .tar.gz no se pudo leer: puede exceder el límite de "
+            "previsualización una vez descomprimido, o estar corrupto"
+        ) from e
+
+    result = _parse_csv_bytes(inner_raw, max_rows, truncated=truncated)
+    result["format"] = "tar_gz"
+    result["member_name"] = member.name
+    return result
 
 
 def format_table(headers: list[str], rows: list[list[str]], max_col_width: int = 40) -> str:

--- a/helpers/csv_reader.py
+++ b/helpers/csv_reader.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import tarfile
+import zipfile
 import zlib
 from typing import Any
 
@@ -435,6 +436,21 @@ def _gunzip_capped(raw: bytes, cap: int = _MAX_DECOMPRESSED_BYTES) -> tuple[byte
     return bytes(out[:cap]), len(out) > cap
 
 
+def _pick_member(names: list[str]) -> str | None:
+    """Pick the best-priority member name: .csv > .tsv > .txt > first available.
+
+    Prevents a bundled readme.txt from winning over the actual data file
+    just because it comes first in the archive.
+    """
+    if not names:
+        return None
+    for ext in (".csv", ".tsv", ".txt"):
+        match = next((n for n in names if n.lower().endswith(ext)), None)
+        if match is not None:
+            return match
+    return names[0]
+
+
 async def preview_targz(
     url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
@@ -445,7 +461,7 @@ async def preview_targz(
 
     try:
         with tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:") as tar:
-            members = [m for m in tar.getmembers() if m.isfile()]
+            members = {m.name: m for m in tar.getmembers() if m.isfile()}
             if not members:
                 return {
                     "headers": [],
@@ -454,28 +470,61 @@ async def preview_targz(
                     "truncated": truncated,
                     "format": "tar_gz",
                 }
-            # Prefer .csv over .tsv over .txt: a bundled readme.txt should not
-            # win over the actual data file just because it comes first.
-            member = None
-            for ext in (".csv", ".tsv", ".txt"):
-                member = next(
-                    (m for m in members if m.name.lower().endswith(ext)), None
-                )
-                if member is not None:
-                    break
-            if member is None:
-                member = members[0]
-            extracted = tar.extractfile(member)
-            inner_raw = extracted.read(MAX_DOWNLOAD_BYTES) if extracted else b""
+            member_name = _pick_member(list(members))
+            extracted = tar.extractfile(members[member_name])
+            inner_raw = extracted.read(MAX_DOWNLOAD_BYTES + 1) if extracted else b""
     except tarfile.TarError as e:
         raise ValueError(
             "El archivo .tar.gz no se pudo leer: puede exceder el límite de "
             "previsualización una vez descomprimido, o estar corrupto"
         ) from e
 
+    truncated = truncated or len(inner_raw) > MAX_DOWNLOAD_BYTES
+    inner_raw = inner_raw[:MAX_DOWNLOAD_BYTES]
+
     result = _parse_csv_bytes(inner_raw, max_rows, truncated=truncated)
     result["format"] = "tar_gz"
-    result["member_name"] = member.name
+    result["member_name"] = member_name
+    return result
+
+
+async def preview_zip(
+    url: str, max_rows: int = 20, session: httpx.AsyncClient | None = None
+) -> dict[str, Any]:
+    """Preview the first CSV/TSV-like member inside a .zip archive.
+
+    Unlike .tar.gz, a .zip's central directory lists members without
+    decompressing anything, so there is no need for a capped-decompression
+    pass up front — bounding the single chosen member's `.read()` call is
+    enough to keep a decompression bomb from blowing up memory.
+    """
+    raw, truncated = await download_bytes(url, session=session)
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            names = [n for n in zf.namelist() if not n.endswith("/")]
+            if not names:
+                return {
+                    "headers": [],
+                    "rows": [],
+                    "total_rows_in_preview": 0,
+                    "truncated": truncated,
+                    "format": "zip",
+                }
+            member_name = _pick_member(names)
+            with zf.open(member_name) as f:
+                inner_raw = f.read(MAX_DOWNLOAD_BYTES + 1)
+    except zipfile.BadZipFile as e:
+        raise ValueError(
+            "El archivo .zip no se pudo leer: está corrupto o incompleto"
+        ) from e
+
+    truncated = truncated or len(inner_raw) > MAX_DOWNLOAD_BYTES
+    inner_raw = inner_raw[:MAX_DOWNLOAD_BYTES]
+
+    result = _parse_csv_bytes(inner_raw, max_rows, truncated=truncated)
+    result["format"] = "zip"
+    result["member_name"] = member_name
     return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "mcp>=1.25.0,<2",
     "openpyxl>=3.1.0",
     "uvicorn>=0.30.0",
+    "xlrd>=2.0.2",
 ]
 
 [build-system]

--- a/tests/test_csv_reader.py
+++ b/tests/test_csv_reader.py
@@ -1,9 +1,14 @@
+import gzip
+import io
 import socket
+import tarfile
 
 from helpers.csv_reader import (
     MAX_DOWNLOAD_BYTES,
+    _gunzip_capped,
     download_bytes,
     normalize_eu_decimal_columns,
+    preview_targz,
     strip_geometry_columns,
 )
 
@@ -101,3 +106,73 @@ async def test_download_bytes_over_limit_is_truncated(httpx_mock, monkeypatch):
     _content, truncated = await download_bytes(url)
 
     assert truncated is True
+
+
+def _make_targz(members: dict[str, bytes]) -> bytes:
+    tar_buf = io.BytesIO()
+    with tarfile.open(fileobj=tar_buf, mode="w") as tar:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return gzip.compress(tar_buf.getvalue())
+
+
+def test_gunzip_capped_returns_full_payload_when_under_cap():
+    raw = b"hello world" * 100
+    payload = gzip.compress(raw)
+
+    decompressed, capped = _gunzip_capped(payload, cap=1024 * 1024)
+
+    assert capped is False
+    assert decompressed == raw
+
+
+def test_gunzip_capped_stops_at_cap():
+    payload = gzip.compress(b"x" * (5 * 1024 * 1024))
+
+    decompressed, capped = _gunzip_capped(payload, cap=1024)
+
+    assert capped is True
+    assert len(decompressed) == 1024
+
+
+async def test_preview_targz_reads_embedded_csv(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    csv_bytes = b"provincia,monto\nPichincha,100\nGuayas,200\n"
+    gz_bytes = _make_targz({"datos.csv": csv_bytes})
+    url = "https://example.com/datos.tar.gz"
+    httpx_mock.add_response(url=url, content=gz_bytes)
+
+    result = await preview_targz(url)
+
+    assert result["headers"] == ["provincia", "monto"]
+    assert result["rows"] == [["Pichincha", "100"], ["Guayas", "200"]]
+    assert result["format"] == "tar_gz"
+    assert result["member_name"] == "datos.csv"
+    assert result["truncated"] is False
+
+
+async def test_preview_targz_picks_csv_member_over_other_files(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    gz_bytes = _make_targz(
+        {
+            "readme.txt": b"metadata not the data",
+            "datos.csv": b"a,b\n1,2\n",
+        }
+    )
+    url = "https://example.com/mixto.tar.gz"
+    httpx_mock.add_response(url=url, content=gz_bytes)
+
+    result = await preview_targz(url)
+
+    assert result["member_name"] == "datos.csv"
+    assert result["headers"] == ["a", "b"]

--- a/tests/test_csv_reader.py
+++ b/tests/test_csv_reader.py
@@ -2,6 +2,9 @@ import gzip
 import io
 import socket
 import tarfile
+import zipfile
+
+import pytest
 
 from helpers.csv_reader import (
     MAX_DOWNLOAD_BYTES,
@@ -9,6 +12,7 @@ from helpers.csv_reader import (
     download_bytes,
     normalize_eu_decimal_columns,
     preview_targz,
+    preview_zip,
     strip_geometry_columns,
 )
 
@@ -176,3 +180,65 @@ async def test_preview_targz_picks_csv_member_over_other_files(httpx_mock, monke
 
     assert result["member_name"] == "datos.csv"
     assert result["headers"] == ["a", "b"]
+
+
+def _make_zip(members: dict[str, bytes]) -> bytes:
+    zip_buf = io.BytesIO()
+    with zipfile.ZipFile(zip_buf, mode="w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    return zip_buf.getvalue()
+
+
+async def test_preview_zip_reads_embedded_csv(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    csv_bytes = b"provincia,monto\nPichincha,100\nGuayas,200\n"
+    zip_bytes = _make_zip({"datos.csv": csv_bytes})
+    url = "https://example.com/datos.zip"
+    httpx_mock.add_response(url=url, content=zip_bytes)
+
+    result = await preview_zip(url)
+
+    assert result["headers"] == ["provincia", "monto"]
+    assert result["rows"] == [["Pichincha", "100"], ["Guayas", "200"]]
+    assert result["format"] == "zip"
+    assert result["member_name"] == "datos.csv"
+    assert result["truncated"] is False
+
+
+async def test_preview_zip_picks_csv_member_over_other_files(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    zip_bytes = _make_zip(
+        {
+            "readme.txt": b"metadata not the data",
+            "datos.csv": b"a,b\n1,2\n",
+        }
+    )
+    url = "https://example.com/mixto.zip"
+    httpx_mock.add_response(url=url, content=zip_bytes)
+
+    result = await preview_zip(url)
+
+    assert result["member_name"] == "datos.csv"
+    assert result["headers"] == ["a", "b"]
+
+
+async def test_preview_zip_rejects_corrupt_archive(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    url = "https://example.com/corrupto.zip"
+    httpx_mock.add_response(url=url, content=b"not a real zip file")
+
+    with pytest.raises(ValueError, match="no se pudo leer"):
+        await preview_zip(url)

--- a/tests/test_preview_resource_data.py
+++ b/tests/test_preview_resource_data.py
@@ -64,7 +64,7 @@ def test_classify_json_and_geojson():
 # -- dispatch through the tool ------------------------------------------------
 
 
-async def test_sri_tar_gz_declared_csv_is_not_sent_to_csv_parser(monkeypatch):
+async def test_sri_tar_gz_declared_csv_is_routed_to_targz_parser(monkeypatch):
     async def fake_get_resource(resource_id, session=None):
         return {
             "url": "https://sri.example/sri_activos_2025.tar.gz",
@@ -72,16 +72,31 @@ async def test_sri_tar_gz_declared_csv_is_not_sent_to_csv_parser(monkeypatch):
             "name": "SRI activos",
         }
 
+    calls = []
+
+    async def fake_preview_targz(url, max_rows=20, session=None):
+        calls.append(url)
+        return {
+            "headers": ["ruc", "total"],
+            "rows": [["1234567890001", "100"]],
+            "total_rows_in_preview": 1,
+            "format": "tar_gz",
+            "member_name": "sri_activos_2025.csv",
+        }
+
     async def fail_preview_csv(*args, **kwargs):
         raise AssertionError("preview_csv should not be called for a .tar.gz resource")
 
     monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(preview_resource_data_module, "preview_targz", fake_preview_targz)
     monkeypatch.setattr(preview_resource_data_module, "preview_csv", fail_preview_csv)
 
     tool = _make_tool()
     result = await tool(resource_id="abc123", format="json")
     payload = json.loads(result)
-    assert payload["error"] == "tar_gz_no_soportado"
+    assert payload["headers"] == ["ruc", "total"]
+    assert payload["member_name"] == "sri_activos_2025.csv"
+    assert calls == ["https://sri.example/sri_activos_2025.tar.gz"]
 
 
 async def test_mpceip_xlsx_declared_csv_is_routed_to_xlsx_parser(monkeypatch):
@@ -128,15 +143,33 @@ async def test_rar_message_does_not_overclaim_unrar_requirement(monkeypatch):
     assert "download_resource('abc123', format=\"json\")" in result
 
 
-async def test_xls_message_points_to_download_resource_with_json_format(monkeypatch):
+async def test_xls_is_routed_to_xls_parser(monkeypatch):
     async def fake_get_resource(resource_id, session=None):
         return {"url": "https://x/reporte.xls", "format": "XLS", "name": "Reporte"}
 
+    calls = []
+
+    async def fake_preview_xls(url, max_rows=20, session=None):
+        calls.append(url)
+        return {
+            "headers": ["producto", "precio"],
+            "rows": [["cacao", "174.77"]],
+            "total_rows_in_preview": 1,
+            "format": "xls",
+        }
+
+    async def fail_preview_csv(*args, **kwargs):
+        raise AssertionError("preview_csv should not be called for a .xls resource")
+
     monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(preview_resource_data_module, "preview_xls", fake_preview_xls)
+    monkeypatch.setattr(preview_resource_data_module, "preview_csv", fail_preview_csv)
 
     tool = _make_tool()
-    result = await tool(resource_id="abc123", format="text")
-    assert "download_resource('abc123', format=\"json\")" in result
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["headers"] == ["producto", "precio"]
+    assert calls == ["https://x/reporte.xls"]
 
 
 async def test_resource_not_found_returns_error(monkeypatch):

--- a/tests/test_preview_resource_data.py
+++ b/tests/test_preview_resource_data.py
@@ -37,13 +37,18 @@ def test_classify_rar_by_extension_even_if_declared_csv():
 
 def test_classify_falls_back_to_declared_format_without_recognizable_extension():
     assert classify_resource_format("RAR", "https://x/download?id=123") == "RAR"
+    assert classify_resource_format("ZIP", "https://x/download?id=123") == "ZIP"
     assert classify_resource_format("XLS", "https://x/download?id=123") == "XLS"
     assert classify_resource_format("JSON", "https://x/download?id=123") == "JSON"
     assert classify_resource_format("CSV", "https://x/download?id=123") == "CSV"
     # No format declared and no recognizable extension: same "assume CSV"
     # default the tool has always used (empty format is treated as CSV).
     assert classify_resource_format("", "https://x/download?id=123") == "CSV"
-    assert classify_resource_format("ZIP", "https://x/download?id=123") == "UNKNOWN"
+    assert classify_resource_format("7Z", "https://x/download?id=123") == "UNKNOWN"
+
+
+def test_classify_zip_by_extension_even_if_declared_csv():
+    assert classify_resource_format("CSV", "https://x/archivo.zip") == "ZIP"
 
 
 def test_classify_plain_csv():
@@ -97,6 +102,41 @@ async def test_sri_tar_gz_declared_csv_is_routed_to_targz_parser(monkeypatch):
     assert payload["headers"] == ["ruc", "total"]
     assert payload["member_name"] == "sri_activos_2025.csv"
     assert calls == ["https://sri.example/sri_activos_2025.tar.gz"]
+
+
+async def test_zip_declared_csv_is_routed_to_zip_parser(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {
+            "url": "https://x/precios_cacao.zip",
+            "format": "CSV",
+            "name": "Precios cacao",
+        }
+
+    calls = []
+
+    async def fake_preview_zip(url, max_rows=20, session=None):
+        calls.append(url)
+        return {
+            "headers": ["producto", "precio"],
+            "rows": [["cacao", "174.77"]],
+            "total_rows_in_preview": 1,
+            "format": "zip",
+            "member_name": "precios_cacao.csv",
+        }
+
+    async def fail_preview_csv(*args, **kwargs):
+        raise AssertionError("preview_csv should not be called for a .zip resource")
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(preview_resource_data_module, "preview_zip", fake_preview_zip)
+    monkeypatch.setattr(preview_resource_data_module, "preview_csv", fail_preview_csv)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["headers"] == ["producto", "precio"]
+    assert payload["member_name"] == "precios_cacao.csv"
+    assert calls == ["https://x/precios_cacao.zip"]
 
 
 async def test_mpceip_xlsx_declared_csv_is_routed_to_xlsx_parser(monkeypatch):

--- a/tools/download_resource.py
+++ b/tools/download_resource.py
@@ -17,8 +17,8 @@ def register_download_resource_tool(mcp: FastMCP) -> None:
         Download a resource's raw bytes from Ecuador's open data portal, base64-encoded.
 
         Use this for formats preview_resource_data can't parse into a table
-        (.rar, .tar.gz, legacy .xls, or anything unrecognized) — it fetches
-        the file as-is instead of trying to read it. Max size: 5 MB (same
+        (.rar, or anything unrecognized) — it fetches the file as-is instead
+        of trying to read it. Max size: 5 MB (same
         cap as preview_resource_data). Larger files come back with an error
         and the direct URL instead, since they'd be too big to embed in a
         response.

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -2,7 +2,14 @@ import httpx
 from mcp.server.fastmcp import FastMCP
 
 from helpers import ckan_client
-from helpers.csv_reader import format_table, preview_csv, preview_json, preview_xlsx
+from helpers.csv_reader import (
+    format_table,
+    preview_csv,
+    preview_json,
+    preview_targz,
+    preview_xls,
+    preview_xlsx,
+)
 from helpers.format_out import render_output
 from helpers.logging import log_tool
 
@@ -57,12 +64,13 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
         """
         Download and preview a resource from Ecuador's open data portal.
 
-        Supports CSV/TSV, JSON/GeoJSON and Excel (XLSX). Returns the first N rows
-        as a formatted table so the model can inspect data without a local download.
-        Geometry/WKT columns are dropped from the table (they can be tens of KB
-        per cell); CSV columns in European decimal notation (7.760,2) are
-        normalized to standard notation (7760.2). Max download size: 5 MB. For
-        large tabular DataStore resources prefer query_resource_data.
+        Supports CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX), and .tar.gz archives that
+        wrap a CSV/TSV/TXT file. Returns the first N rows as a formatted table so
+        the model can inspect data without a local download. Geometry/WKT columns
+        are dropped from the table (they can be tens of KB per cell); CSV columns
+        in European decimal notation (7.760,2) are normalized to standard notation
+        (7760.2). Max download size: 5 MB. For large tabular DataStore resources
+        prefer query_resource_data.
 
         Args:
             resource_id: The resource UUID (get it from list_dataset_resources)
@@ -124,36 +132,10 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                     ),
                 )
             if kind == "TARGZ":
-                return render_output(
-                    {
-                        "error": "tar_gz_no_soportado",
-                        "url": url,
-                        "resource_id": resource_id,
-                    },
-                    format,
-                    text_builder=lambda d: (
-                        "Este recurso es un archivo .tar.gz. Todavía no lo previsualizamos "
-                        "como tabla, pero puedes bajar el archivo completo con "
-                        f"download_resource('{d['resource_id']}', format=\"json\"), "
-                        f"o directamente desde: {d['url']}"
-                    ),
-                )
-            if kind == "XLS":
-                return render_output(
-                    {
-                        "error": "xls_no_soportado",
-                        "url": url,
-                        "resource_id": resource_id,
-                    },
-                    format,
-                    text_builder=lambda d: (
-                        "Este recurso es Excel legacy (.xls), que no previsualizamos como "
-                        f"tabla. Puedes bajarlo con "
-                        f"download_resource('{d['resource_id']}', format=\"json\") "
-                        f"y abrirlo localmente, o desde: {d['url']}"
-                    ),
-                )
-            if kind == "XLSX":
+                result = await preview_targz(url, max_rows=rows)
+            elif kind == "XLS":
+                result = await preview_xls(url, max_rows=rows)
+            elif kind == "XLSX":
                 result = await preview_xlsx(url, max_rows=rows)
             elif kind == "JSON":
                 result = await preview_json(url, max_rows=rows)
@@ -170,7 +152,8 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                     format,
                     text_builder=lambda d: (
                         f"Este recurso tiene formato '{d.get('format_detectado') or 'desconocido'}'. "
-                        "preview_resource_data soporta CSV/TSV, JSON/GeoJSON y XLSX. "
+                        "preview_resource_data soporta CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) "
+                        "y .tar.gz (si envuelve un CSV/TSV/TXT). "
                         "Si está en DataStore prueba query_resource_data. "
                         f"Descarga directa: {d['url']}"
                     ),
@@ -210,6 +193,7 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
             "total_rows_in_preview": result["total_rows_in_preview"],
             "truncated": result.get("truncated", False),
             "sheet": result.get("sheet"),
+            "member_name": result.get("member_name"),
             "total_records": result.get("total_records"),
             "dropped_columns": result.get("dropped_columns"),
             "converted_decimal_columns": result.get("converted_decimal_columns"),
@@ -225,6 +209,8 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
             ]
             if data.get("sheet"):
                 parts.append(f"Hoja: {data['sheet']}")
+            if data.get("member_name"):
+                parts.append(f"Archivo interno (.tar.gz): {data['member_name']}")
             if data.get("total_records") is not None:
                 parts.append(f"Registros totales (en archivo): {data['total_records']}")
             if data.get("truncated"):

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -9,6 +9,7 @@ from helpers.csv_reader import (
     preview_targz,
     preview_xls,
     preview_xlsx,
+    preview_zip,
 )
 from helpers.format_out import render_output
 from helpers.logging import log_tool
@@ -19,7 +20,7 @@ _XLSX_FORMATS = {"XLSX", "EXCEL"}
 
 
 def classify_resource_format(fmt: str, url: str) -> str:
-    """Classify a resource as RAR/TARGZ/XLS/XLSX/JSON/CSV/UNKNOWN.
+    """Classify a resource as RAR/TARGZ/ZIP/XLS/XLSX/JSON/CSV/UNKNOWN.
 
     CKAN's declared `format` is frequently wrong (e.g. a .tar.gz or .xlsx
     file tagged "CSV" by whoever published it), so a recognizable URL
@@ -31,6 +32,8 @@ def classify_resource_format(fmt: str, url: str) -> str:
         return "RAR"
     if url_lower.endswith((".tar.gz", ".tgz")):
         return "TARGZ"
+    if url_lower.endswith(".zip"):
+        return "ZIP"
     if url_lower.endswith(".xlsx"):
         return "XLSX"
     if url_lower.endswith(".xls"):
@@ -42,6 +45,8 @@ def classify_resource_format(fmt: str, url: str) -> str:
 
     if fmt == "RAR":
         return "RAR"
+    if fmt == "ZIP":
+        return "ZIP"
     if fmt == "XLS":
         return "XLS"
     if fmt in _XLSX_FORMATS:
@@ -64,9 +69,9 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
         """
         Download and preview a resource from Ecuador's open data portal.
 
-        Supports CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX), and .tar.gz archives that
-        wrap a CSV/TSV/TXT file. Returns the first N rows as a formatted table so
-        the model can inspect data without a local download. Geometry/WKT columns
+        Supports CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX), and .tar.gz/.zip archives
+        that wrap a CSV/TSV/TXT file. Returns the first N rows as a formatted table
+        so the model can inspect data without a local download. Geometry/WKT columns
         are dropped from the table (they can be tens of KB per cell); CSV columns
         in European decimal notation (7.760,2) are normalized to standard notation
         (7760.2). Max download size: 5 MB. For large tabular DataStore resources
@@ -133,6 +138,8 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                 )
             if kind == "TARGZ":
                 result = await preview_targz(url, max_rows=rows)
+            elif kind == "ZIP":
+                result = await preview_zip(url, max_rows=rows)
             elif kind == "XLS":
                 result = await preview_xls(url, max_rows=rows)
             elif kind == "XLSX":
@@ -153,7 +160,7 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                     text_builder=lambda d: (
                         f"Este recurso tiene formato '{d.get('format_detectado') or 'desconocido'}'. "
                         "preview_resource_data soporta CSV/TSV, JSON/GeoJSON, Excel (XLS/XLSX) "
-                        "y .tar.gz (si envuelve un CSV/TSV/TXT). "
+                        "y .tar.gz/.zip (si envuelven un CSV/TSV/TXT). "
                         "Si está en DataStore prueba query_resource_data. "
                         f"Descarga directa: {d['url']}"
                     ),
@@ -210,7 +217,7 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
             if data.get("sheet"):
                 parts.append(f"Hoja: {data['sheet']}")
             if data.get("member_name"):
-                parts.append(f"Archivo interno (.tar.gz): {data['member_name']}")
+                parts.append(f"Archivo interno: {data['member_name']}")
             if data.get("total_records") is not None:
                 parts.append(f"Registros totales (en archivo): {data['total_records']}")
             if data.get("truncated"):

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,7 @@ dependencies = [
     { name = "mcp" },
     { name = "openpyxl" },
     { name = "uvicorn" },
+    { name = "xlrd" },
 ]
 
 [package.dev-dependencies]
@@ -248,6 +249,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.25.0,<2" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
+    { name = "xlrd", specifier = ">=2.0.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -878,4 +880,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]


### PR DESCRIPTION
## Resumen

- **Excel legado (.xls)**: `preview_resource_data` ahora lo previsualiza como tabla vía `xlrd` (pura Python, sin binario externo), en vez de solo señalar `xls_no_soportado` y apuntar a `download_resource`.
- **Archivos `.tar.gz`**: se descomprimen (`tarfile` + `zlib` de la stdlib, sin dependencia nueva) y se previsualiza el CSV/TSV/TXT interno como tabla, en vez de solo detectarlos y ofrecer la descarga cruda.
  - La descompresión tiene un tope de 20 MB para acotar el impacto de un archivo diseñado para expandirse desproporcionadamente al descomprimirlo (el límite de descarga en bruto ya es de 5 MB, pero un `.tar.gz` muy compresible podría inflarse mucho más que eso).
- **Archivos `.zip`**: mismo tratamiento, vía `zipfile` de la stdlib. El directorio central de un `.zip` lista los miembros sin descomprimir nada, así que no hace falta el paso de descompresión con tope que sí necesita `.tar.gz` — basta con acotar la lectura del miembro elegido.
  - Ambos formatos comparten la misma lógica de selección de miembro (`helpers/csv_reader._pick_member`): se prioriza `.csv` > `.tsv` > `.txt` en vez de tomar el primero del archivo — esto evita que un `readme.txt` empaquetado junto al dato real gane la selección (bug real que encontré escribiendo el test de esta función).
- Se extrajo la lógica de parseo de CSV a una función compartida (`_parse_csv_bytes`) para reutilizarla entre `preview_csv`, `preview_targz` y `preview_zip`, sin cambios de comportamiento en `preview_csv`.
- Se confirma en `ROADMAP.md` que el certificado TLS de `www.datosabiertos.gob.ec` ya fue renovado (Let's Encrypt, válido hasta 2026-11-05) — el ítem estaba marcado como pendiente de revisión.
- Fix menor: `preview_targz` no marcaba `truncated=True` cuando el archivo interno superaba los 5 MB por sí solo; y el docstring de `download_resource` seguía listando `.tar.gz`/`.xls` como formatos sin preview, desactualizado desde que se agregó soporte para ambos.
- Entrada agregada en `CHANGELOG.md` bajo `## Unreleased`, sin auto-asignar número de versión, siguiendo la convención que ya existe en el repo (`d61e41e`/`55f5c5f`) de dejar el versionado como paso único al momento de cortar el release.

## Plan de pruebas

- `uv run pytest -q` → 148 tests pasan (17 nuevos: previsualización real de `.tar.gz`/`.zip` construidos en memoria vía `httpx_mock`, tests unitarios de la función de descompresión con tope, tests de prioridad `.csv`/`.tsv`/`.txt` para ambos formatos, test de archivo `.zip` corrupto, y tests de dispatch en `preview_resource_data` para `.xls`, `.tar.gz` y `.zip`).
- `uv run ruff check .` → sin errores.

🤖 Generado con [Claude Code](https://claude.com/claude-code)