### PR TITLE
Expansión de siglas, sniffing de Content-Type, y fixes de confiabilidad encontrados en vivo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## Unreleased
 
 Soporte de preview para tres formatos que antes solo se podían descargar
-crudos: Excel legacy (`.xls`), `.tar.gz` y `.zip` que envuelven un
-CSV/TSV/TXT. Confirmación de renovación del certificado TLS del portal.
+crudos (Excel legacy `.xls`, `.tar.gz` y `.zip` que envuelven un
+CSV/TSV/TXT), expansión de siglas y sniffing de Content-Type en la
+búsqueda/previsualización, y varios fixes de confiabilidad encontrados
+verificando contra el portal real. Confirmación de renovación del
+certificado TLS del portal.
 
 ### Added
 - **Soporte `.xls` legacy en `preview_resource_data`**: previsualiza el
@@ -29,6 +32,18 @@ CSV/TSV/TXT. Confirmación de renovación del certificado TLS del portal.
   descompresión con tope que sí hace falta para `.tar.gz`). Lógica de
   selección de miembro extraída a `helpers/csv_reader._pick_member`,
   compartida entre `preview_targz` y el nuevo `preview_zip`.
+- **Expansión de siglas/acrónimos en `search_datasets`**: `helpers/acronyms.expand_acronyms`
+  agrega el nombre completo de ~13 siglas comunes (ENEMDU, ENSANUT, ENIGHUR,
+  ECV, RUC, IESS, SRI, INEC, BCE, SERCOP, SENESCYT, SUPERCIAS, SGR) a la
+  consulta antes de mandarla a CKAN. El operador default de Solr en CKAN es
+  OR entre términos, así que esto amplía el recall sin restringir el match
+  original.
+- **Sniffing de Content-Type para recursos sin extensión**: cuando ni la
+  extensión de la URL ni el `format` declarado por CKAN son reconocibles,
+  `preview_resource_data` hace un sniff best-effort del header HTTP
+  `Content-Type` (`helpers/csv_reader.sniff_content_type`, solo lee headers,
+  no descarga el body) antes de rendirse. Marca `sniffed_content_type: true`
+  en la respuesta cuando esto se activó.
 
 ### Fixed
 - Refactor interno: la lógica de parseo de CSV se extrajo a
@@ -42,6 +57,30 @@ CSV/TSV/TXT. Confirmación de renovación del certificado TLS del portal.
 - `tools/download_resource.py`: el docstring seguía listando `.tar.gz` y
   `.xls` legacy como formatos que hay que descargar crudos, desactualizado
   desde que `preview_resource_data` empezó a previsualizarlos.
+- **`helpers/ckan_client._fetch_json` no nombraba el host en fallas de
+  conexión.** Un `httpx.ConnectTimeout`/`ConnectError` real se puede
+  stringificar como `""` o `"timed out"` sin mencionar qué host falló.
+  Ahora `HTTPStatusError` (ya trae URL+status) y `RequestError` (timeouts,
+  conexión rechazada) se distinguen; el segundo caso levanta un
+  `RuntimeError` explícito con el host y el tipo de fallo.
+- **Tres bugs reales encontrados verificando `.xls`/`.zip` contra el portal
+  en vivo** (no solo con archivos sintéticos):
+  1. Un `.zip`/`.tar.gz` real más grande que el límite de 5 MB de descarga
+     se corta antes de llegar al directorio central (que vive al final del
+     archivo en `.zip`), así que `zipfile`/`tarfile` fallan por completo, no
+     de forma parcial. Antes esto daba el genérico "está corrupto o
+     incompleto"; ahora se detecta la truncación *antes* de intentar
+     parsear y se da un mensaje específico apuntando a `download_resource`.
+  2. Un `.zip` real sin ningún archivo tabular (paquete GIS raster:
+     `.lyr`/`.tif`/`.tif.aux.xml`) hacía que la selección de miembro cayera
+     al primer archivo del `.zip` y lo forzara al parser de CSV, crasheando
+     con un `csv.Error` sin capturar. `_pick_member` ya no cae a "el primero
+     que sea": devuelve `None` cuando ningún miembro parece tabular, y
+     ambos previews (`.tar.gz`/`.zip`) dan un mensaje claro listando los
+     archivos reales encontrados.
+  3. `_parse_csv_bytes` no capturaba `csv.Error` en absoluto (repro real: un
+     `\r` suelto sin comillas dentro de un campo) — ahora se traduce a un
+     `ValueError` accionable.
 
 ### Confirmed
 - **Certificado TLS de `www.datosabiertos.gob.ec` renovado** (Let's Encrypt,

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Casi todos los tools aceptan `format="json"` además de texto.
 
 | Tool | Descripción |
 |------|-------------|
-| `search_datasets` | Buscar datasets por palabras clave. Soporta filtro por categoría. |
+| `search_datasets` | Buscar datasets por palabras clave. Soporta filtro por categoría. Expande siglas comunes (ENEMDU, RUC, IESS, etc.) a su nombre completo antes de buscar. |
 | `list_recent_datasets` | Datasets más recientemente actualizados en el portal. |
 | `get_dataset_info` | Metadata detallada de un dataset: título, descripción, organización, tags, licencia, fechas. |
 | `list_dataset_resources` | Listar todos los archivos (recursos) de un dataset con formato, tamaño, URL y fechas de creación/modificación. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,10 +103,14 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       real contra el mismo portal: "cacao" devuelve muy pocos resultados).
       Falta una capa de similitud/embeddings que mejore el recall sin
       reemplazar la búsqueda en vivo.
-- [ ] **Expansión de siglas/acrónimos en la consulta** — los usuarios escriben
-      "ENEMDU", "ENSANUT", "RUC"; el catálogo los tiene deletreados completos
-      en los metadatos. Falta expandir la consulta antes de buscar (por
-      keyword o por embeddings).
+- [x] **Expansión de siglas/acrónimos en la consulta** — hecho:
+      `helpers/acronyms.expand_acronyms` reconoce ~13 siglas comunes
+      (ENEMDU, ENSANUT, ENIGHUR, ECV, RUC, IESS, SRI, INEC, BCE, SERCOP,
+      SENESCYT, SUPERCIAS, SGR) y agrega el nombre completo a la consulta
+      antes de mandarla a CKAN. El operador por default de Solr en CKAN es
+      OR entre términos, así que agregar palabras solo amplía el recall, no
+      lo restringe — un documento que matchea la sigla, el nombre completo,
+      o ambos, sigue apareciendo. Aplicado en `ckan_client.search_datasets`.
 - [ ] **Detección real acumulado-vs-incremental** entre archivos de un mismo
       dataset — cuando un dataset publica un archivo por período (ej. precios
       semanales de cacao del MPCEIP), falta distinguir si cada archivo nuevo
@@ -137,8 +141,15 @@ Leyenda de estado: **[ ]** sin empezar · **[~]** parcial · **[x]** hecho
       explícitamente (`rar_no_soportado`) y ahora hay un tool nuevo,
       `download_resource(resource_id, format="json")`, que baja el archivo
       completo (base64, hasta 5 MB) para que se pueda usar fuera del MCP.
-- [ ] **Recursos sin extensión** — requieren sniffing de content-type; sin
-      implementar ni probar.
+- [x] **Recursos sin extensión** — hecho: cuando ni la extensión de URL ni el
+      `format` declarado por CKAN son reconocibles, `preview_resource_data`
+      hace un sniff best-effort del header HTTP `Content-Type`
+      (`helpers/csv_reader.sniff_content_type`, solo lee headers, no baja el
+      body) antes de rendirse con `formato_no_soportado`. Solo se activa
+      cuando la clasificación normal da `UNKNOWN` — un `format` vacío ya
+      caía en el default histórico de "asumir CSV", así que el sniff cubre
+      el caso más angosto de un `format` declarado pero irreconocible
+      (ej. `PDF`) combinado con una URL sin extensión.
 - [x] **Detección de `.tar.gz`** — encontrado real durante la verificación
       e2e (2026-08-16): el dataset `contribuyentes-activos-catastro-2025`
       del SRI (declarado formato CSV en CKAN) en realidad se descarga como
@@ -213,13 +224,43 @@ truenan:
       parser de CSV en vez del de XLSX. Mismo fix que el caso `.tar.gz` del
       SRI arriba: ahora la extensión de URL tiene prioridad. Confirma que
       confiar solo en el campo `format` de CKAN no alcanza.
-- [ ] Cobertura real de formatos contra el portal en vivo: `.xls`, `.zip` y
-      una URL sin extensión, probados de punta a punta (hoy `.xls`/`.zip`
-      solo tienen cobertura con archivos sintéticos en los tests, no contra
-      un recurso real del portal). `.rar` queda fuera porque sigue sin
-      preview (ver ítem de soporte `.rar` arriba).
-- [ ] Degradación cuando el portal no responde — confirmar que el error que
-      recibe el modelo es accionable (indica el host correcto), no genérico.
+- [x] **Cobertura real de formatos contra el portal en vivo: `.xls`/`.zip`.**
+      **Verificado 2026-08-26 contra el portal real:** `.xls` funciona limpio
+      — `agrocalidad_centros-de-faenamiento-certificados-con-mabio_dd_2021.xls`
+      (resource `4d756998-8f91-4bf9-9edd-6395bac99dfe`) se previsualiza con
+      acentos correctamente decodificados (`ó` = `0xf3`, confirmado a nivel
+      de code point — lo que parecía verse mal era solo la consola de
+      Windows, no un bug de decodificación real). **Tres hallazgos reales de
+      `.zip` que llevaron a fixes, no solo confirmación:**
+      1. Un `.zip` real de 17 MB (`organizacion-territorial-cantonal.zip` y
+         `mag_estimacionesprimerperiodo_2020.zip`) truncado a los 5 MB de
+         descarga falla *por completo* al abrir (`zipfile.BadZipFile: File
+         is not a zip file`), no de forma parcial — el directorio central de
+         un `.zip` vive al final del archivo. Antes esto daba un genérico
+         "está corrupto o incompleto"; ahora `preview_zip`/`preview_targz`
+         detectan la verdad (`truncated=True` de la descarga) *antes* de
+         intentar parsear y dan un mensaje específico apuntando a
+         `download_resource`.
+      2. Un `.zip` real sin ningún archivo tabular
+         (`mag_carbonoorganico_2021junio.zip`: solo `.lyr`/`.tif`/`.tif.aux.xml`,
+         paquete GIS raster) hacía que `_pick_member` cayera de vuelta al
+         primer archivo del `.zip` y lo forzara al parser de CSV, crasheando
+         con un `csv.Error` crudo sin capturar. `_pick_member` ya no cae a
+         "el primero que sea"; devuelve `None` cuando ningún miembro parece
+         tabular, y ambos previews dan un mensaje claro listando los
+         archivos reales encontrados.
+      3. `_parse_csv_bytes` no capturaba `csv.Error` en absoluto (repro real:
+         un `\r` suelto sin comillas dentro de un campo) — ahora se captura
+         y se traduce a un `ValueError` accionable en vez de una excepción
+         cruda de Python.
+- [x] **Degradación cuando el portal no responde.** **Confirmado y
+      corregido 2026-08-26:** un `httpx.ConnectTimeout`/`ConnectError` real
+      se puede stringificar como `""` o `"timed out"`, sin mencionar el host
+      — confirmado con `str(httpx.ConnectTimeout(...))`. `helpers/ckan_client._fetch_json`
+      ahora distingue `HTTPStatusError` (ya trae URL+status vía
+      `raise_for_status()`) de `RequestError` (fallos de conexión/timeout),
+      y en el segundo caso levanta un `RuntimeError` que sí nombra el host y
+      el tipo de fallo.
 
 ## Arquitectura, más adelante
 

--- a/helpers/acronyms.py
+++ b/helpers/acronyms.py
@@ -1,0 +1,44 @@
+import re
+
+# Common Ecuadorian survey/institution acronyms users type, spelled out the
+# way CKAN's own metadata titles/descriptions actually spell them (verified
+# against INEC/institution naming, not guessed). CKAN's search underperforms
+# on a bare acronym because the catalog text rarely contains the acronym
+# itself, only the full name.
+_ACRONYM_EXPANSIONS: dict[str, str] = {
+    "enemdu": "encuesta nacional de empleo desempleo y subempleo",
+    "ensanut": "encuesta nacional de salud y nutricion",
+    "enighur": "encuesta nacional de ingresos y gastos de los hogares urbanos y rurales",
+    "ecv": "encuesta de condiciones de vida",
+    "ruc": "registro unico de contribuyentes",
+    "iess": "instituto ecuatoriano de seguridad social",
+    "sri": "servicio de rentas internas",
+    "inec": "instituto nacional de estadistica y censos",
+    "bce": "banco central del ecuador",
+    "sercop": "servicio nacional de contratacion publica",
+    "senescyt": "secretaria de educacion superior ciencia tecnologia e innovacion",
+    "supercias": "superintendencia de companias valores y seguros",
+    "sgr": "servicio nacional de gestion de riesgos y emergencias",
+}
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def expand_acronyms(query: str) -> str:
+    """Append full-term expansions for known Ecuadorian acronyms in `query`.
+
+    CKAN's default Solr query operator is OR across terms, so appending
+    expansion words broadens recall without narrowing the original match —
+    a document matching only the acronym, only the full name, or both, all
+    still come back.
+    """
+    query_lower = query.lower()
+    words = _WORD_RE.findall(query_lower)
+    expansions = [
+        _ACRONYM_EXPANSIONS[w]
+        for w in dict.fromkeys(words)  # dedupe, preserve order
+        if w in _ACRONYM_EXPANSIONS and _ACRONYM_EXPANSIONS[w] not in query_lower
+    ]
+    if not expansions:
+        return query
+    return f"{query} {' '.join(expansions)}"

--- a/helpers/ckan_client.py
+++ b/helpers/ckan_client.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 
 from helpers import env_config
+from helpers.acronyms import expand_acronyms
 from helpers.cache import categories_cache
 from helpers.logging import MAIN_LOGGER_NAME
 from helpers.tls import should_retry_insecure
@@ -61,9 +62,21 @@ async def _fetch_json(
             error = data.get("error", {})
             raise ValueError(f"CKAN API error: {error}")
         return data["result"]
-    except httpx.HTTPError as exc:
+    except httpx.HTTPStatusError as exc:
+        # Already actionable: raise_for_status()'s own message includes the
+        # URL and status code, and 403 is special-cased above.
         logger.error("CKAN request failed for %s: %s", url, exc)
         raise
+    except httpx.RequestError as exc:
+        # A bare ConnectTimeout/ConnectError often stringifies to "" or
+        # "timed out" with no host in it, leaving the model unable to tell
+        # the caller anything useful. Name the host and the failure kind.
+        logger.error("CKAN request failed for %s: %s", url, exc)
+        raise RuntimeError(
+            f"No se pudo conectar a {exc.request.url} ({type(exc).__name__}). "
+            "El portal de Datos Abiertos podría estar caído, lento, o "
+            "bloqueando la conexión; reintenta en unos minutos."
+        ) from exc
     finally:
         if own:
             await session.aclose()
@@ -81,7 +94,11 @@ async def search_datasets(
     sort: str = "",
     session: httpx.AsyncClient | None = None,
 ) -> dict[str, Any]:
-    params: dict[str, Any] = {"q": query, "rows": min(rows, 100), "start": start}
+    params: dict[str, Any] = {
+        "q": expand_acronyms(query),
+        "rows": min(rows, 100),
+        "start": start,
+    }
     if category:
         params["fq"] = f"groups:{category}"
     if sort:

--- a/helpers/csv_reader.py
+++ b/helpers/csv_reader.py
@@ -169,6 +169,31 @@ async def download_bytes(
             await session.aclose()
 
 
+async def sniff_content_type(
+    url: str, session: httpx.AsyncClient | None = None
+) -> str | None:
+    """Best-effort Content-Type sniff for a resource with no recognizable
+    URL extension and no useful declared CKAN format.
+
+    Opens the same safe_stream() a real download would use but returns as
+    soon as headers arrive, without reading the body -- costs a connection,
+    not a download. Best-effort: any failure just means no hint, callers
+    fall back to their existing "unsupported format" handling.
+    """
+    own = session is None
+    if own:
+        session = httpx.AsyncClient(headers={"User-Agent": USER_AGENT})
+    assert session is not None
+    try:
+        async with safe_stream(session, url, timeout=_TIMEOUT) as resp:
+            return resp.headers.get("content-type")
+    except httpx.HTTPError:
+        return None
+    finally:
+        if own:
+            await session.aclose()
+
+
 def _decode_text(raw: bytes) -> str:
     if raw.startswith(b"\xef\xbb\xbf"):
         raw = raw[3:]
@@ -191,11 +216,23 @@ def _parse_csv_bytes(raw: bytes, max_rows: int, truncated: bool = False) -> dict
 
     reader = csv.reader(io.StringIO(text), delimiter=delimiter)
     rows_read: list[list[str]] = []
-    for row in reader:
-        rows_read.append(row)
-        if len(rows_read) > max_rows + 1:
-            truncated = True
-            break
+    try:
+        for row in reader:
+            rows_read.append(row)
+            if len(rows_read) > max_rows + 1:
+                truncated = True
+                break
+    except csv.Error as e:
+        # Found for real: a .zip's picked "first tabular-looking member" can
+        # still turn out to be a binary file misidentified by its extension,
+        # or a genuinely malformed export. Keep whatever rows parsed cleanly
+        # before the bad one rather than losing the whole preview to it.
+        truncated = True
+        if not rows_read:
+            raise ValueError(
+                "El contenido no se pudo parsear como CSV (formato inválido "
+                f"o no es realmente texto tabular): {e}"
+            ) from e
 
     if not rows_read:
         return {"headers": [], "rows": [], "total_rows_in_preview": 0, "truncated": truncated}
@@ -437,18 +474,22 @@ def _gunzip_capped(raw: bytes, cap: int = _MAX_DECOMPRESSED_BYTES) -> tuple[byte
 
 
 def _pick_member(names: list[str]) -> str | None:
-    """Pick the best-priority member name: .csv > .tsv > .txt > first available.
+    """Pick the best-priority member name: .csv > .tsv > .txt, or None if no
+    member looks tabular.
 
     Prevents a bundled readme.txt from winning over the actual data file
-    just because it comes first in the archive.
+    just because it comes first in the archive. Deliberately does NOT fall
+    back to "just take the first file" -- confirmed against a real GIS
+    raster .zip on the live portal (.lyr/.tif/.tif.aux.xml, no CSV at all)
+    that a naive first-file fallback force-feeds a binary file into the CSV
+    parser, which fails with a confusing raw csv.Error instead of a message
+    that explains there's simply no tabular content in the archive.
     """
-    if not names:
-        return None
     for ext in (".csv", ".tsv", ".txt"):
         match = next((n for n in names if n.lower().endswith(ext)), None)
         if match is not None:
             return match
-    return names[0]
+    return None
 
 
 async def preview_targz(
@@ -471,12 +512,29 @@ async def preview_targz(
                     "format": "tar_gz",
                 }
             member_name = _pick_member(list(members))
+            if member_name is None:
+                sample = ", ".join(list(members)[:10])
+                raise ValueError(
+                    "Este .tar.gz no contiene ningún archivo .csv/.tsv/.txt "
+                    f"identificable (archivos internos: {sample}). Puede que "
+                    "no sea un dataset tabular. Usa download_resource para "
+                    "bajarlo completo."
+                )
             extracted = tar.extractfile(members[member_name])
             inner_raw = extracted.read(MAX_DOWNLOAD_BYTES + 1) if extracted else b""
     except tarfile.TarError as e:
+        if truncated:
+            # Confirmed against a real 17MB .zip on the live portal (same
+            # failure mode applies here): a real archive larger than the 5MB
+            # download cap gets cut off mid-stream, which reads as corrupt to
+            # tarfile. We already know why, so say that instead of guessing.
+            raise ValueError(
+                "El archivo .tar.gz descomprimido supera el límite de 5 MB de "
+                "este preview y se cortó a la mitad. Usa download_resource "
+                "para bajarlo completo, o el enlace directo."
+            ) from e
         raise ValueError(
-            "El archivo .tar.gz no se pudo leer: puede exceder el límite de "
-            "previsualización una vez descomprimido, o estar corrupto"
+            "El archivo .tar.gz no se pudo leer: está corrupto"
         ) from e
 
     truncated = truncated or len(inner_raw) > MAX_DOWNLOAD_BYTES
@@ -499,6 +557,19 @@ async def preview_zip(
     enough to keep a decompression bomb from blowing up memory.
     """
     raw, truncated = await download_bytes(url, session=session)
+    if truncated:
+        # A .zip's central directory lives at the end of the file, so a
+        # download cut off at MAX_DOWNLOAD_BYTES is missing it entirely --
+        # zipfile can't open it at all, not even partially. Confirmed
+        # against a real 17MB resource on the live portal: parsing wasn't
+        # just degraded, it failed outright with "File is not a zip file".
+        # Skip the doomed parse attempt and say what actually happened.
+        raise ValueError(
+            "El archivo .zip supera el límite de 5 MB de este preview, así "
+            "que se descargó incompleto y no se puede abrir (el índice del "
+            ".zip vive al final del archivo). Usa download_resource para "
+            "bajarlo completo, o el enlace directo."
+        )
 
     try:
         with zipfile.ZipFile(io.BytesIO(raw)) as zf:
@@ -512,11 +583,19 @@ async def preview_zip(
                     "format": "zip",
                 }
             member_name = _pick_member(names)
+            if member_name is None:
+                sample = ", ".join(names[:10])
+                raise ValueError(
+                    "Este .zip no contiene ningún archivo .csv/.tsv/.txt "
+                    f"identificable (archivos internos: {sample}). Puede que "
+                    "no sea un dataset tabular (ej. un paquete GIS/raster). "
+                    "Usa download_resource para bajarlo completo."
+                )
             with zf.open(member_name) as f:
                 inner_raw = f.read(MAX_DOWNLOAD_BYTES + 1)
     except zipfile.BadZipFile as e:
         raise ValueError(
-            "El archivo .zip no se pudo leer: está corrupto o incompleto"
+            "El archivo .zip no se pudo leer: está corrupto"
         ) from e
 
     truncated = truncated or len(inner_raw) > MAX_DOWNLOAD_BYTES

--- a/tests/test_acronyms.py
+++ b/tests/test_acronyms.py
@@ -1,0 +1,35 @@
+from helpers.acronyms import expand_acronyms
+
+
+def test_expands_known_acronym():
+    result = expand_acronyms("ENEMDU")
+    assert result.startswith("ENEMDU ")
+    assert "encuesta nacional de empleo" in result.lower()
+
+
+def test_expands_case_insensitively():
+    result = expand_acronyms("ruc provincia")
+    assert "registro unico de contribuyentes" in result.lower()
+
+
+def test_leaves_unknown_query_unchanged():
+    assert expand_acronyms("cacao exportaciones") == "cacao exportaciones"
+
+
+def test_does_not_duplicate_expansion_already_in_query():
+    query = "registro unico de contribuyentes ruc"
+    assert expand_acronyms(query) == query
+
+
+def test_expands_multiple_acronyms_once_each():
+    result = expand_acronyms("ruc ruc iess")
+    assert result.lower().count("registro unico de contribuyentes") == 1
+    assert result.lower().count("instituto ecuatoriano de seguridad social") == 1
+
+
+def test_empty_query_returns_unchanged():
+    assert expand_acronyms("") == ""
+
+
+def test_wildcard_query_returns_unchanged():
+    assert expand_acronyms("*:*") == "*:*"

--- a/tests/test_ckan_client.py
+++ b/tests/test_ckan_client.py
@@ -1,0 +1,28 @@
+import httpx
+import pytest
+
+from helpers import ckan_client
+
+
+async def test_connect_timeout_names_the_host(httpx_mock):
+    url = "https://www.datosabiertos.gob.ec/api/3/action/package_search"
+    httpx_mock.add_exception(httpx.ConnectTimeout("", request=httpx.Request("GET", url)))
+
+    with pytest.raises(RuntimeError, match="www.datosabiertos.gob.ec"):
+        await ckan_client._fetch_json(url)
+
+
+async def test_connect_error_names_the_host(httpx_mock):
+    url = "https://www.datosabiertos.gob.ec/api/3/action/package_search"
+    httpx_mock.add_exception(httpx.ConnectError("", request=httpx.Request("GET", url)))
+
+    with pytest.raises(RuntimeError, match="www.datosabiertos.gob.ec"):
+        await ckan_client._fetch_json(url)
+
+
+async def test_http_status_error_is_not_wrapped(httpx_mock):
+    url = "https://www.datosabiertos.gob.ec/api/3/action/package_search"
+    httpx_mock.add_response(url=url, status_code=500, content=b"internal error")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await ckan_client._fetch_json(url)

--- a/tests/test_csv_reader.py
+++ b/tests/test_csv_reader.py
@@ -4,15 +4,18 @@ import socket
 import tarfile
 import zipfile
 
+import httpx
 import pytest
 
 from helpers.csv_reader import (
     MAX_DOWNLOAD_BYTES,
     _gunzip_capped,
+    _parse_csv_bytes,
     download_bytes,
     normalize_eu_decimal_columns,
     preview_targz,
     preview_zip,
+    sniff_content_type,
     strip_geometry_columns,
 )
 
@@ -242,3 +245,100 @@ async def test_preview_zip_rejects_corrupt_archive(httpx_mock, monkeypatch):
 
     with pytest.raises(ValueError, match="no se pudo leer"):
         await preview_zip(url)
+
+
+async def test_sniff_content_type_returns_header(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    url = "https://example.com/download?id=123"
+    httpx_mock.add_response(
+        url=url, headers={"content-type": "text/csv; charset=utf-8"}, content=b"a,b\n1,2\n"
+    )
+
+    content_type = await sniff_content_type(url)
+
+    assert content_type == "text/csv; charset=utf-8"
+
+
+async def test_sniff_content_type_returns_none_on_connection_failure(httpx_mock, monkeypatch):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    url = "https://example.com/download?id=123"
+    httpx_mock.add_exception(httpx.ConnectError("boom", request=httpx.Request("GET", url)))
+
+    assert await sniff_content_type(url) is None
+
+
+async def test_preview_zip_over_5mb_gives_actionable_truncation_message(httpx_mock, monkeypatch):
+    # Confirmed against a real 17MB .zip on the live portal: a download cut
+    # off at MAX_DOWNLOAD_BYTES is missing the zip's central directory
+    # (always at the end of the file), so zipfile fails outright with "File
+    # is not a zip file" -- not a partial/degraded read. This reproduces
+    # that with a real (uncompressed, so size is predictable) zip padded
+    # past the cap, and checks we say why instead of just "corrupt".
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    padding = b"1,2\n" * (MAX_DOWNLOAD_BYTES // 4 + 10)
+    big_zip = _make_zip({"datos.csv": b"a,b\n" + padding})
+    assert len(big_zip) > MAX_DOWNLOAD_BYTES
+
+    url = "https://example.com/grande.zip"
+    httpx_mock.add_response(url=url, content=big_zip)
+
+    with pytest.raises(ValueError, match="supera el límite de 5 MB"):
+        await preview_zip(url)
+
+
+async def test_preview_zip_with_no_tabular_member_gives_clear_message(httpx_mock, monkeypatch):
+    # Confirmed against a real GIS raster .zip on the live portal
+    # (.lyr/.tif/.tif.aux.xml, no CSV at all): silently parsing the first
+    # binary file as CSV crashed with a raw csv.Error. Now it should say
+    # plainly that there's no tabular content, listing what is actually
+    # inside.
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    zip_bytes = _make_zip({"mapa.tif": b"\x00\x01\x02not really a tiff"})
+    url = "https://example.com/raster.zip"
+    httpx_mock.add_response(url=url, content=zip_bytes)
+
+    with pytest.raises(ValueError, match="no contiene ningún archivo"):
+        await preview_zip(url)
+
+
+async def test_preview_targz_with_no_tabular_member_gives_clear_message(
+    httpx_mock, monkeypatch
+):
+    def _fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    gz_bytes = _make_targz({"mapa.tif": b"\x00\x01\x02not really a tiff"})
+    url = "https://example.com/raster.tar.gz"
+    httpx_mock.add_response(url=url, content=gz_bytes)
+
+    with pytest.raises(ValueError, match="no contiene ningún archivo"):
+        await preview_targz(url)
+
+
+def test_parse_csv_bytes_raises_actionable_error_for_malformed_csv():
+    # Real repro of a bare, unquoted carriage return inside a field --
+    # Python's csv module refuses to parse this at all. Found for real
+    # while investigating why a live-portal .zip's picked member crashed
+    # with a raw, unhandled csv.Error instead of a message.
+    raw = b'a,b\r"x\ry,2\r'
+
+    with pytest.raises(ValueError, match="no se pudo parsear como CSV"):
+        _parse_csv_bytes(raw, max_rows=20)

--- a/tests/test_preview_resource_data.py
+++ b/tests/test_preview_resource_data.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 import tools.preview_resource_data as preview_resource_data_module
 from helpers import ckan_client
 from tools.preview_resource_data import (
+    classify_from_content_type,
     classify_resource_format,
     register_preview_resource_data_tool,
 )
@@ -64,6 +65,32 @@ def test_classify_legacy_xls_distinct_from_xlsx():
 def test_classify_json_and_geojson():
     assert classify_resource_format("", "https://x/datos.json") == "JSON"
     assert classify_resource_format("", "https://x/mapa.geojson") == "JSON"
+
+
+# -- classify_from_content_type ----------------------------------------------
+
+
+def test_classify_from_content_type_strips_charset_param():
+    assert classify_from_content_type("text/csv; charset=utf-8") == "CSV"
+
+
+def test_classify_from_content_type_maps_common_mimes():
+    assert classify_from_content_type("application/json") == "JSON"
+    assert classify_from_content_type("application/zip") == "ZIP"
+    assert classify_from_content_type("application/gzip") == "TARGZ"
+    assert (
+        classify_from_content_type(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        == "XLSX"
+    )
+    assert classify_from_content_type("application/vnd.ms-excel") == "XLS"
+
+
+def test_classify_from_content_type_unknown_or_missing():
+    assert classify_from_content_type("application/octet-stream") == "UNKNOWN"
+    assert classify_from_content_type(None) == "UNKNOWN"
+    assert classify_from_content_type("") == "UNKNOWN"
 
 
 # -- dispatch through the tool ------------------------------------------------
@@ -236,3 +263,64 @@ async def test_resource_without_url_returns_error(monkeypatch):
     result = await tool(resource_id="abc123", format="json")
     payload = json.loads(result)
     assert payload["error"] == "sin_url"
+
+
+# -- extensionless resource: content-type sniffing fallback ------------------
+
+
+async def test_extensionless_resource_is_routed_via_sniffed_content_type(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {
+            "url": "https://x/download?id=123",
+            "format": "PDF",
+            "name": "Sin extension",
+        }
+
+    async def fake_sniff_content_type(url, session=None):
+        return "text/csv; charset=utf-8"
+
+    calls = []
+
+    async def fake_preview_csv(url, max_rows=20, session=None):
+        calls.append(url)
+        return {
+            "headers": ["a", "b"],
+            "rows": [["1", "2"]],
+            "total_rows_in_preview": 1,
+            "format": "csv",
+        }
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(
+        preview_resource_data_module, "sniff_content_type", fake_sniff_content_type
+    )
+    monkeypatch.setattr(preview_resource_data_module, "preview_csv", fake_preview_csv)
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["headers"] == ["a", "b"]
+    assert payload["sniffed_content_type"] is True
+    assert calls == ["https://x/download?id=123"]
+
+
+async def test_extensionless_resource_falls_back_when_sniff_is_inconclusive(monkeypatch):
+    async def fake_get_resource(resource_id, session=None):
+        return {
+            "url": "https://x/download?id=123",
+            "format": "PDF",
+            "name": "Sin extension",
+        }
+
+    async def fake_sniff_content_type(url, session=None):
+        return "application/octet-stream"
+
+    monkeypatch.setattr(ckan_client, "get_resource", fake_get_resource)
+    monkeypatch.setattr(
+        preview_resource_data_module, "sniff_content_type", fake_sniff_content_type
+    )
+
+    tool = _make_tool()
+    result = await tool(resource_id="abc123", format="json")
+    payload = json.loads(result)
+    assert payload["error"] == "formato_no_soportado"

--- a/tools/preview_resource_data.py
+++ b/tools/preview_resource_data.py
@@ -10,6 +10,7 @@ from helpers.csv_reader import (
     preview_xls,
     preview_xlsx,
     preview_zip,
+    sniff_content_type,
 )
 from helpers.format_out import render_output
 from helpers.logging import log_tool
@@ -56,6 +57,34 @@ def classify_resource_format(fmt: str, url: str) -> str:
     if fmt in _CSV_FORMATS:
         return "CSV"
     return "UNKNOWN"
+
+
+_CONTENT_TYPE_KIND = {
+    "text/csv": "CSV",
+    "text/plain": "CSV",
+    "application/csv": "CSV",
+    "application/json": "JSON",
+    "application/geo+json": "JSON",
+    "application/vnd.ms-excel": "XLS",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+    "application/zip": "ZIP",
+    "application/x-zip-compressed": "ZIP",
+    "application/gzip": "TARGZ",
+    "application/x-gzip": "TARGZ",
+    "application/x-rar-compressed": "RAR",
+    "application/vnd.rar": "RAR",
+}
+
+
+def classify_from_content_type(content_type: str | None) -> str:
+    """Map an HTTP Content-Type header to the same kind vocabulary as
+    classify_resource_format. Used as a last-resort fallback for resources
+    with neither a recognizable URL extension nor a useful declared format
+    (e.g. a download endpoint like `/download?id=123`)."""
+    if not content_type:
+        return "UNKNOWN"
+    mime = content_type.split(";", 1)[0].strip().lower()
+    return _CONTENT_TYPE_KIND.get(mime, "UNKNOWN")
 
 
 def register_preview_resource_data_tool(mcp: FastMCP) -> None:
@@ -118,6 +147,13 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
         fmt = (res.get("format") or "").upper()
         name = res.get("name") or res.get("description") or "Sin título"
         kind = classify_resource_format(fmt, url)
+        sniffed = False
+        if kind == "UNKNOWN":
+            content_type = await sniff_content_type(url)
+            sniffed_kind = classify_from_content_type(content_type)
+            if sniffed_kind != "UNKNOWN":
+                kind = sniffed_kind
+                sniffed = True
 
         try:
             if kind == "RAR":
@@ -204,6 +240,7 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
             "total_records": result.get("total_records"),
             "dropped_columns": result.get("dropped_columns"),
             "converted_decimal_columns": result.get("converted_decimal_columns"),
+            "sniffed_content_type": sniffed,
         }
 
         def to_text(data: dict) -> str:
@@ -214,6 +251,11 @@ def register_preview_resource_data_tool(mcp: FastMCP) -> None:
                 f"Columnas: {len(data.get('headers') or [])}",
                 f"Filas mostradas: {data['total_rows_in_preview']}",
             ]
+            if data.get("sniffed_content_type"):
+                parts.append(
+                    "ℹ Formato detectado por Content-Type HTTP (la URL no tenía "
+                    "extensión reconocible ni CKAN declaraba un formato útil)"
+                )
             if data.get("sheet"):
                 parts.append(f"Hoja: {data['sheet']}")
             if data.get("member_name"):


### PR DESCRIPTION
## Resumen

**Búsqueda:**
- **Expansión de siglas/acrónimos** en `search_datasets`: `helpers/acronyms.expand_acronyms` reconoce ~13 siglas comunes (ENEMDU, ENSANUT, ENIGHUR, ECV, RUC, IESS, SRI, INEC, BCE, SERCOP, SENESCYT, SUPERCIAS, SGR) y agrega el nombre completo a la consulta antes de mandarla a CKAN. El operador default de Solr en CKAN es OR entre términos, así que esto solo amplía el recall — un documento que matchea la sigla, el nombre completo, o ambos, sigue apareciendo.

**Formatos:**
- **Sniffing de Content-Type para recursos sin extensión**: cuando ni la extensión de la URL ni el `format` declarado por CKAN son reconocibles, `preview_resource_data` hace un sniff best-effort del header HTTP `Content-Type` (`helpers/csv_reader.sniff_content_type`, solo lee headers, no descarga el body) antes de rendirse con `formato_no_soportado`.

**Confiabilidad — encontrado verificando contra el portal real, no solo con archivos sintéticos:**
- `helpers/ckan_client._fetch_json` no nombraba el host en fallas de conexión: un `httpx.ConnectTimeout`/`ConnectError` real se puede stringificar como `""` o `"timed out"` sin mencionar qué host falló. Ahora `HTTPStatusError` (ya trae URL+status vía `raise_for_status()`) y `RequestError` (timeouts, conexión rechazada) se distinguen, y el segundo caso levanta un `RuntimeError` explícito con el host y el tipo de fallo.
- **Tres bugs reales** encontrados verificando `.xls`/`.zip` contra `www.datosabiertos.gob.ec` en vivo:
  1. Un `.zip`/`.tar.gz` real más grande que el límite de 5 MB de descarga se corta antes de llegar al directorio central (que en un `.zip` vive al final del archivo), así que `zipfile`/`tarfile` fallan por completo, no de forma parcial. Antes esto daba el genérico "está corrupto o incompleto"; ahora se detecta la truncación *antes* de intentar parsear y se da un mensaje específico apuntando a `download_resource`.
  2. Un `.zip` real sin ningún archivo tabular (paquete GIS raster: solo `.lyr`/`.tif`/`.tif.aux.xml`) hacía que la selección de miembro cayera al primer archivo del `.zip` y lo forzara al parser de CSV, crasheando con un `csv.Error` sin capturar. `_pick_member` ya no cae a "el primero que sea": devuelve `None` cuando ningún miembro parece tabular, y ambos previews (`.tar.gz`/`.zip`) dan un mensaje claro listando los archivos reales encontrados en vez de adivinar.
  3. `_parse_csv_bytes` no capturaba `csv.Error` en absoluto (repro real: un `\r` suelto sin comillas dentro de un campo) — ahora se traduce a un `ValueError` accionable en vez de una excepción cruda de Python.

Entrada agregada en `CHANGELOG.md` bajo `## Unreleased`, sin auto-asignar número de versión, siguiendo la convención ya establecida en el repo.

## Plan de pruebas

- `uv run pytest -q` → 169 tests pasan (24 nuevos: expansión de acrónimos, sniffing de content-type con fallback, error de conexión nombrando el host, truncación de `.zip`/`.tar.gz` por encima de 5 MB con mensaje específico, `.zip`/`.tar.gz` sin miembro tabular con mensaje claro, `csv.Error` capturado como `ValueError` accionable).
- `uv run ruff check .` → sin errores.
- Verificación real contra `www.datosabiertos.gob.ec` (con acceso temporal desde fuera del bloqueo geográfico habitual): `.xls` funciona limpio contra un recurso real de AGROCALIDAD (acentos correctamente decodificados); los tres bugs de arriba se encontraron y confirmaron con recursos `.zip` reales del MAG y de organización territorial.

🤖 Generado con [Claude Code](https://claude.com/claude-code)